### PR TITLE
Use typing generics for broader Python compatibility

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -5,7 +5,7 @@ import hashlib
 import sys
 from datetime import date, timedelta
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 import pandas as pd
 import plotly.express as px
@@ -40,7 +40,7 @@ def load_datasets(
     }
 
 
-def _default_period(df: pd.DataFrame) -> tuple[date, date]:
+def _default_period(df: pd.DataFrame) -> Tuple[date, date]:
     if df.empty:
         today = date.today()
         return today.replace(day=1), today
@@ -90,7 +90,7 @@ def _hash_bytes(payload: bytes) -> str:
 def _handle_csv_uploads(
     uploads: Dict[str, Optional[object]],
     baseline: Dict[str, pd.DataFrame],
-) -> tuple[Dict[str, pd.DataFrame], Dict[str, data_loader.ValidationResult]]:
+) -> Tuple[Dict[str, pd.DataFrame], Dict[str, data_loader.ValidationResult]]:
     datasets = _copy_datasets(baseline)
     validations: Dict[str, data_loader.ValidationResult] = {}
 
@@ -122,7 +122,7 @@ def _handle_csv_uploads(
 def _handle_api_mode(
     api_state: Dict[str, object],
     baseline: Dict[str, pd.DataFrame],
-) -> tuple[Dict[str, pd.DataFrame], Optional[IntegrationResult]]:
+) -> Tuple[Dict[str, pd.DataFrame], Optional[IntegrationResult]]:
     provider = api_state.get("provider")
     stored = st.session_state.get("api_datasets")
     datasets = _copy_datasets(stored or baseline)
@@ -280,7 +280,7 @@ def render_sales_tab(
 def render_products_tab(
     filtered_sales: pd.DataFrame,
     comparison_sales: pd.DataFrame,
-) -> tuple[pd.DataFrame, pd.DataFrame]:
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
     st.subheader("ABC分析")
     abc_df = products.abc_analysis(filtered_sales, comparison_sales)
     if abc_df.empty:

--- a/streamlit_app/components/import_dashboard.py
+++ b/streamlit_app/components/import_dashboard.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 from uuid import uuid4
 
 import pandas as pd
@@ -248,7 +248,7 @@ def _summarize_dataset(dataset: str, dataframe: pd.DataFrame) -> Dict[str, float
     return {}
 
 
-def _errors_to_records(errors_df: Optional[pd.DataFrame]) -> list[dict]:
+def _errors_to_records(errors_df: Optional[pd.DataFrame]) -> List[Dict[str, object]]:
     if errors_df is None or errors_df.empty:
         return []
     return errors_df.to_dict(orient="records")

--- a/streamlit_app/components/sidebar.py
+++ b/streamlit_app/components/sidebar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import date, timedelta
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Dict, List, Tuple
 
 import streamlit as st
 
@@ -33,13 +33,13 @@ def _resolve_date_range(value: Tuple[date, date]) -> Tuple[date, date]:
 
 
 def render_sidebar(
-    stores: list[str],
-    categories: list[str],
+    stores: List[str],
+    categories: List[str],
     *,
     default_period: Tuple[date, date],
     sample_files: Dict[str, str],
     templates: Dict[str, bytes],
-    providers: list[str],
+    providers: List[str],
 ) -> Dict[str, object]:
     st.sidebar.header("データソース")
     mode_label = st.sidebar.radio("連携方法", ["CSVアップロード", "API連携"])

--- a/streamlit_app/data_loader.py
+++ b/streamlit_app/data_loader.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
-from typing import IO, Callable, Dict, Iterable, Optional, Union
+from typing import IO, Callable, Dict, Iterable, List, Optional, Union
 
 import pandas as pd
 
@@ -158,7 +158,7 @@ def load_fixed_costs(source: Optional[CsvSource] = None) -> pd.DataFrame:
     return df
 
 
-def available_sample_files() -> dict[str, Path]:
+def available_sample_files() -> Dict[str, Path]:
     """Return paths to the built-in sample CSV files."""
     return {
         "sales": SAMPLE_DATA_DIR / "sales.csv",
@@ -250,7 +250,7 @@ def _validate_dataset(
 ) -> ValidationResult:
     df_raw = _coerce_to_dataframe(source, default_path=default_path)
     total_rows = len(df_raw)
-    errors: list[Dict[str, object]] = []
+    errors: List[Dict[str, object]] = []
 
     missing = set(required_columns) - set(df_raw.columns)
     if missing:

--- a/streamlit_app/integrations/manager.py
+++ b/streamlit_app/integrations/manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import date, datetime
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from .clients import DatasetBundle, PROVIDER_CLIENTS, get_client
 
@@ -25,7 +25,7 @@ class IntegrationResult:
         return f"{self.start_date:%Y-%m-%d} 〜 {self.end_date:%Y-%m-%d}"
 
 
-def available_providers() -> list[str]:
+def available_providers() -> List[str]:
     """Return the list of supported integration providers."""
 
     return list(PROVIDER_CLIENTS.keys())

--- a/streamlit_app/transformers.py
+++ b/streamlit_app/transformers.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
+from typing import List
+
 import pandas as pd
 
 
@@ -58,12 +60,12 @@ def apply_filters(df: pd.DataFrame, filters: FilterState) -> pd.DataFrame:
     return dataset
 
 
-def extract_stores(df: pd.DataFrame) -> list[str]:
+def extract_stores(df: pd.DataFrame) -> List[str]:
     stores = sorted(df["store"].unique().tolist())
     return [ALL_STORES, *stores]
 
 
-def extract_categories(df: pd.DataFrame) -> list[str]:
+def extract_categories(df: pd.DataFrame) -> List[str]:
     categories = sorted(df["category"].unique().tolist())
     return [ALL_CATEGORIES, *categories]
 


### PR DESCRIPTION
## Summary
- replace usage of PEP 585 built-in generics like `list[str]` and `tuple[...]` with `typing` module aliases
- update multiple modules to import `List` and `Tuple` as needed for compatibility with Python 3.8 runtimes

## Testing
- python -m compileall streamlit_app

------
https://chatgpt.com/codex/tasks/task_e_68d27aecbe588323b3ae2c8b228b7d25