### PR TITLE
Avoid runtime dependency on data_loader in import dashboard

### DIFF
--- a/streamlit_app/components/import_dashboard.py
+++ b/streamlit_app/components/import_dashboard.py
@@ -2,14 +2,17 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 from uuid import uuid4
 
 import pandas as pd
 import streamlit as st
 
-from streamlit_app.data_loader import ValidationResult
 from streamlit_app.integrations import IntegrationResult
+
+
+if TYPE_CHECKING:
+    from streamlit_app.data_loader import ValidationResult
 
 
 _HISTORY_KEY = "import_history"


### PR DESCRIPTION
## Summary
- defer the ValidationResult import in the import dashboard component to type-checking time to avoid runtime import issues

## Testing
- python -m compileall streamlit_app/components/import_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68d280d4d4dc83238b8dacaf8de2a8ac