### PR TITLE
Refactor dashboard navigation and analytics layout

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -6,9 +6,10 @@ import logging
 import sys
 from datetime import date, timedelta
 from pathlib import Path
-from typing import Callable, Dict, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 import pandas as pd
+from pandas.tseries.offsets import MonthEnd
 import plotly.express as px
 import plotly.graph_objects as go
 import streamlit as st
@@ -267,45 +268,686 @@ def _log_integration_result(result: IntegrationResult) -> None:
         )
 
 
-def render_sales_tab(
-    filtered_sales: pd.DataFrame,
+GLOBAL_FILTER_KEY = "global_filters"
+NAV_STATE_KEY = "active_main_tab"
+DEFAULT_NAV_KEY = "dashboard"
+GLOBAL_FILTER_PRESETS = ["今月", "先月", "直近30日", "カスタム"]
+MAIN_TAB_CONFIG = [
+    ("dashboard", "ダッシュボード"),
+    ("sales", "売上分析"),
+    ("profit", "利益"),
+    ("product", "商品分析"),
+    ("inventory", "在庫"),
+    ("simulation", "経営シミュレーション"),
+    ("data", "データ管理"),
+]
+TARGET_MARGIN_RATE = 0.12
+TARGET_CASH_RATIO = 0.25
+BASE_CASH_BUFFER = 3_000_000.0
+
+
+def _inject_global_styles() -> None:
+    """Inject shared CSS for the redesigned dashboard."""
+
+    st.markdown(
+        """
+        <style>
+        .kpi-card {
+            background: #ffffff;
+            border-radius: 12px;
+            padding: 1.1rem 1.2rem;
+            box-shadow: 0 2px 4px rgba(15, 23, 42, 0.08);
+            margin-bottom: 0.8rem;
+        }
+        .kpi-card .label {
+            font-size: 0.9rem;
+            color: #6b7280;
+            margin-bottom: 0.4rem;
+        }
+        .kpi-card .value {
+            font-size: 1.6rem;
+            font-weight: 600;
+            color: #111827;
+        }
+        .kpi-card .delta {
+            font-size: 0.9rem;
+            font-weight: 500;
+            margin-top: 0.2rem;
+        }
+        .kpi-card .delta.positive {
+            color: #148a4a;
+        }
+        .kpi-card .delta.negative {
+            color: #d93025;
+        }
+        .kpi-card .target {
+            font-size: 0.85rem;
+            margin-top: 0.3rem;
+            color: #4b5563;
+        }
+        .kpi-card .target.positive {
+            color: #148a4a;
+        }
+        .kpi-card .target.negative {
+            color: #d93025;
+        }
+        .alert-box {
+            background: #fef3f2;
+            border: 1px solid #fda29b;
+            border-radius: 12px;
+            padding: 1rem 1.2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            color: #b42318;
+            gap: 1rem;
+        }
+        .alert-box.success {
+            background: #ecfdf3;
+            border-color: #a6f4c5;
+            color: #027a48;
+        }
+        .filter-bar {
+            background: #f8fafc;
+            border: 1px solid #e2e8f0;
+            border-radius: 12px;
+            padding: 0.9rem 1.1rem;
+            margin-bottom: 1rem;
+        }
+        .quick-menu button {
+            width: 100%;
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def _dataset_bounds(df: pd.DataFrame) -> Tuple[date, date]:
+    if df.empty:
+        today = date.today()
+        return today, today
+    min_date = df["date"].min().date()
+    max_date = df["date"].max().date()
+    return min_date, max_date
+
+
+def _to_date(value: object) -> Optional[date]:
+    if isinstance(value, date):
+        return value
+    if isinstance(value, pd.Timestamp):
+        return value.date()
+    return None
+
+
+def _normalize_range(value: object, fallback: Tuple[date, date]) -> Tuple[date, date]:
+    if isinstance(value, (list, tuple)) and len(value) == 2:
+        start = _to_date(value[0]) or fallback[0]
+        end = _to_date(value[1]) or fallback[1]
+    else:
+        start, end = fallback
+    if start > end:
+        start, end = end, start
+    return start, end
+
+
+def _preset_range(
+    preset: str,
+    custom_range: Tuple[date, date],
+    bounds: Tuple[date, date],
+    fallback: Tuple[date, date],
+) -> Tuple[date, date]:
+    min_date, max_date = bounds
+    start, end = fallback
+    if preset == "今月":
+        reference = max_date
+        start = reference.replace(day=1)
+        end = max_date
+    elif preset == "先月":
+        reference = max_date.replace(day=1) - timedelta(days=1)
+        start = reference.replace(day=1)
+        end = reference
+    elif preset == "直近30日":
+        end = max_date
+        start = end - timedelta(days=29)
+    elif preset == "カスタム":
+        start, end = _normalize_range(custom_range, fallback)
+
+    start = max(start, min_date)
+    end = min(end, max_date)
+    if start > end:
+        start, end = end, start
+    return start, end
+
+
+def _format_currency(value: float, unit: str = "円") -> str:
+    return f"{value:,.0f} {unit}" if value == value else f"0 {unit}"
+
+
+def _format_number(value: float, unit: str = "") -> str:
+    suffix = f" {unit}" if unit else ""
+    return f"{value:,.0f}{suffix}"
+
+
+def _format_ratio(value: Optional[float]) -> str:
+    if value is None:
+        return "-"
+    return f"{value*100:.1f}%"
+
+
+def _compute_growth(current: float, previous: Optional[float]) -> Optional[float]:
+    if previous is None or previous == 0:
+        return None
+    return (current - previous) / previous
+
+
+def _render_kpi_cards(cards: Sequence[Dict[str, object]]) -> None:
+    if not cards:
+        return
+    columns = st.columns(len(cards))
+    for column, card in zip(columns, cards):
+        yoy = card.get("yoy")
+        if yoy is None:
+            yoy_text = "前年比: データ不足"
+            delta_class = "neutral"
+        else:
+            arrow = "▲" if yoy >= 0 else "▼"
+            yoy_text = f"前年比: {arrow} {yoy*100:.1f}%"
+            delta_class = "positive" if yoy >= 0 else "negative"
+        target_diff = card.get("target_diff", 0.0)
+        target_class = "positive" if target_diff >= 0 else "negative"
+        target_unit = card.get("unit", "")
+        target_suffix = f" {target_unit}" if target_unit else ""
+        column.markdown(
+            f"""
+            <div class="kpi-card">
+                <div class="label">{card.get('label', '')}</div>
+                <div class="value">{card.get('value_text', '')}</div>
+                <div class="delta {delta_class}">{yoy_text}</div>
+                <div class="target {target_class}">目標差: {target_diff:+,.0f}{target_suffix}</div>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+
+
+def _cash_flow_summary(sales_df: pd.DataFrame, inventory_df: pd.DataFrame) -> Dict[str, float]:
+    if sales_df.empty:
+        return {
+            "deposit": BASE_CASH_BUFFER,
+            "receivable": 0.0,
+            "payable": 0.0,
+            "balance": BASE_CASH_BUFFER,
+        }
+
+    total_sales = float(sales_df["sales_amount"].sum())
+    total_qty = float(sales_df["sales_qty"].sum())
+    total_cogs = float(sales_df["cogs_amount"].sum())
+    period_days = max(
+        1,
+        (sales_df["date"].max() - sales_df["date"].min()).days + 1,
+    )
+
+    deposit = BASE_CASH_BUFFER + (total_sales / max(1.0, period_days)) * 5
+    receivable = total_sales * 0.2
+    avg_cost = total_cogs / total_qty if total_qty else 0.0
+    planned_units = (
+        inventory_df.get("planned_purchase", pd.Series(dtype=float)).sum()
+        if not inventory_df.empty
+        else 0.0
+    )
+    payable = planned_units * avg_cost
+    balance = deposit + receivable - payable
+    return {
+        "deposit": deposit,
+        "receivable": receivable,
+        "payable": payable,
+        "balance": balance,
+    }
+
+
+def render_global_filter_bar(
+    stores: Sequence[str],
+    categories: Sequence[str],
+    *,
+    default_period: Tuple[date, date],
+    bounds: Tuple[date, date],
+) -> transformers.FilterState:
+    state = st.session_state.setdefault(
+        GLOBAL_FILTER_KEY,
+        {
+            "preset": "今月",
+            "custom_range": default_period,
+            "store": transformers.ALL_STORES,
+        },
+    )
+
+    st.markdown("#### 基本フィルタ")
+    with st.container():
+        col1, col2 = st.columns([2, 1])
+        preset_index = (
+            GLOBAL_FILTER_PRESETS.index(state.get("preset", "今月"))
+            if state.get("preset") in GLOBAL_FILTER_PRESETS
+            else 0
+        )
+        preset = col1.selectbox(
+            "期間", GLOBAL_FILTER_PRESETS, index=preset_index
+        )
+
+        store_options = [transformers.ALL_STORES, *stores] if stores else [transformers.ALL_STORES]
+        selected_store = state.get("store", transformers.ALL_STORES)
+        store_index = (
+            store_options.index(selected_store)
+            if selected_store in store_options
+            else 0
+        )
+        store_choice = col2.selectbox(
+            "店舗", store_options, index=store_index
+        )
+
+    custom_range = state.get("custom_range", default_period)
+    if preset == "カスタム":
+        custom_range = st.date_input(
+            "対象期間", value=_normalize_range(custom_range, default_period)
+        )
+    start_date, end_date = _preset_range(
+        preset,
+        _normalize_range(custom_range, default_period),
+        bounds,
+        default_period,
+    )
+
+    state.update(
+        {
+            "preset": preset,
+            "store": store_choice,
+            "custom_range": (start_date, end_date),
+        }
+    )
+
+    selected_stores = list(stores)
+    if store_choice != transformers.ALL_STORES and store_choice:
+        selected_stores = [store_choice]
+
+    filters = transformers.FilterState(
+        stores=selected_stores,
+        start_date=start_date,
+        end_date=end_date,
+        categories=list(categories),
+        regions=[],
+        channels=[],
+        period_granularity="monthly",
+        breakdown_dimension="store",
+    )
+
+    st.caption(
+        f"期間: {start_date:%Y-%m-%d} 〜 {end_date:%Y-%m-%d} ／ 店舗: {store_choice}"
+    )
+    return filters
+
+
+
+def render_dashboard_tab(
+    sales_df: pd.DataFrame,
     comparison_sales: pd.DataFrame,
     filters: transformers.FilterState,
+    fixed_costs_df: pd.DataFrame,
+    inventory_df: pd.DataFrame,
+    *,
+    navigate: Optional[Callable[[str], None]] = None,
+) -> pd.DataFrame:
+    st.markdown("### 経営ダッシュボード")
+
+    filtered_costs = fixed_costs_df.copy()
+    filtered_inventory = inventory_df.copy()
+    if filters.store != transformers.ALL_STORES:
+        filtered_costs = filtered_costs[filtered_costs["store"] == filters.store]
+        filtered_inventory = filtered_inventory[
+            filtered_inventory["store"] == filters.store
+        ]
+
+    pnl_df = profitability.store_profitability(sales_df, filtered_costs)
+    comparison_pnl = (
+        profitability.store_profitability(comparison_sales, filtered_costs)
+        if not comparison_sales.empty
+        else pd.DataFrame(columns=pnl_df.columns)
+    )
+
+    total_sales = float(sales_df["sales_amount"].sum())
+    previous_sales = (
+        float(comparison_sales["sales_amount"].sum())
+        if not comparison_sales.empty
+        else None
+    )
+    sales_target = previous_sales * 1.05 if previous_sales else total_sales * 1.05
+
+    operating_profit = float(
+        pnl_df.get("operating_profit", pd.Series(dtype=float)).sum()
+    )
+    previous_operating_profit = (
+        float(
+            comparison_pnl.get("operating_profit", pd.Series(dtype=float)).sum()
+        )
+        if not comparison_pnl.empty
+        else None
+    )
+    profit_target = sales_target * TARGET_MARGIN_RATE
+
+    cash_current = _cash_flow_summary(sales_df, filtered_inventory)
+    cash_previous = _cash_flow_summary(comparison_sales, filtered_inventory)
+    cash_target = sales_target * TARGET_CASH_RATIO
+
+    _render_kpi_cards(
+        [
+            {
+                "label": "期間売上",
+                "value_text": _format_currency(total_sales),
+                "unit": "円",
+                "yoy": _compute_growth(total_sales, previous_sales),
+                "target_diff": total_sales - sales_target,
+            },
+            {
+                "label": "営業利益",
+                "value_text": _format_currency(operating_profit),
+                "unit": "円",
+                "yoy": _compute_growth(operating_profit, previous_operating_profit),
+                "target_diff": operating_profit - profit_target,
+            },
+            {
+                "label": "資金残高",
+                "value_text": _format_currency(cash_current["balance"]),
+                "unit": "円",
+                "yoy": _compute_growth(
+                    cash_current["balance"], cash_previous.get("balance")
+                ),
+                "target_diff": cash_current["balance"] - cash_target,
+            },
+        ]
+    )
+
+    granularity = "weekly"
+    sales_trend = sales.timeseries_with_comparison(
+        sales_df, comparison_sales, granularity
+    )
+    sales_chart = px.line(
+        sales_trend,
+        x="period_label",
+        y="sales_amount",
+        labels={"period_label": "期間", "sales_amount": "売上"},
+        markers=True,
+    )
+    if sales_trend["comparison_sales"].notna().any():
+        sales_chart.add_trace(
+            go.Scatter(
+                x=sales_trend["period_label"],
+                y=sales_trend["comparison_sales"],
+                mode="lines+markers",
+                name="前期比",
+                line=dict(dash="dash"),
+            )
+        )
+
+    profit_trend = sales.aggregate_timeseries(sales_df, granularity)
+    cost_columns = ["rent", "payroll", "utilities", "marketing", "other_fixed"]
+    total_fixed_cost = 0.0
+    if not filtered_costs.empty:
+        total_fixed_cost = float(
+            filtered_costs[cost_columns].fillna(0).sum(axis=1).sum()
+        )
+    total_sales_for_alloc = float(profit_trend["sales_amount"].sum())
+    if not profit_trend.empty:
+        if total_sales_for_alloc:
+            profit_trend["allocated_fixed"] = (
+                profit_trend["sales_amount"] / total_sales_for_alloc
+            ) * total_fixed_cost
+        else:
+            profit_trend["allocated_fixed"] = total_fixed_cost / max(
+                len(profit_trend), 1
+            )
+        profit_trend["operating_profit"] = (
+            profit_trend["gross_profit"] - profit_trend["allocated_fixed"]
+        )
+
+    profit_chart = px.line(
+        profit_trend,
+        x="period_label",
+        y="gross_profit",
+        labels={"period_label": "期間", "gross_profit": "粗利"},
+        markers=True,
+    )
+    if "operating_profit" in profit_trend.columns:
+        profit_chart.add_trace(
+            go.Scatter(
+                x=profit_trend["period_label"],
+                y=profit_trend["operating_profit"],
+                mode="lines+markers",
+                name="営業利益",
+                line=dict(color="#2563eb"),
+            )
+        )
+
+    col1, col2 = st.columns(2)
+    with col1:
+        st.subheader("売上トレンド")
+        st.plotly_chart(sales_chart, use_container_width=True)
+    with col2:
+        st.subheader("利益トレンド")
+        st.plotly_chart(profit_chart, use_container_width=True)
+
+    overview_df = inventory.inventory_overview(sales_df, filtered_inventory)
+    stockouts = (
+        int((overview_df["stock_status"] == "在庫切れ").sum())
+        if not overview_df.empty
+        else 0
+    )
+    negative_stores = (
+        int((pnl_df["operating_profit"] < 0).sum())
+        if not pnl_df.empty
+        else 0
+    )
+
+    if stockouts or negative_stores:
+        alert_messages = []
+        if stockouts:
+            alert_messages.append(f"在庫欠品{stockouts}件")
+        if negative_stores:
+            alert_messages.append(f"赤字店舗{negative_stores}店")
+        alert_text = "／".join(alert_messages) + " ➜ 詳細へ"
+        container = st.container()
+        with container:
+            col_alert, col_action = st.columns([4, 1])
+            with col_alert:
+                st.markdown(
+                    f"<div class='alert-box'>⚠️ {alert_text}</div>",
+                    unsafe_allow_html=True,
+                )
+            with col_action:
+                if st.button("詳細へ", key="dashboard-alert-detail") and navigate:
+                    if stockouts:
+                        navigate("inventory")
+                    else:
+                        navigate("profit")
+    else:
+        st.markdown(
+            "<div class='alert-box success'>現在アラートはありません。</div>",
+            unsafe_allow_html=True,
+        )
+
+    st.markdown("#### 簡易メニュー")
+    quick_items = [
+        ("sales", "売上分析"),
+        ("profit", "利益"),
+        ("product", "商品分析"),
+        ("inventory", "在庫"),
+        ("simulation", "シミュレーション"),
+        ("data", "データ管理"),
+    ]
+    cols = st.columns(len(quick_items))
+    for col, (key, label) in zip(cols, quick_items):
+        if col.button(label, key=f"quick-menu-{key}") and navigate:
+            navigate(key)
+
+    return pnl_df
+
+
+def render_sales_tab(
+    sales_df: pd.DataFrame,
+    filters: transformers.FilterState,
+    channels: Sequence[str],
+    *,
+    comparison_mode: str,
 ) -> None:
+    st.markdown("### 売上分析")
+
+    state = st.session_state.setdefault(
+        "sales_tab_state",
+        {
+            "channel": transformers.ALL_CHANNELS,
+            "granularity": "monthly",
+            "breakdown": "store",
+            "comparison": comparison_mode,
+        },
+    )
+
+    channel_options = (
+        [transformers.ALL_CHANNELS, *channels]
+        if channels
+        else [transformers.ALL_CHANNELS]
+    )
+    granularity_options = {"月次": "monthly", "週次": "weekly", "日次": "daily"}
+    breakdown_options = {
+        "店舗別": "store",
+        "カテゴリ別": "category",
+        "地域別": "region",
+    }
+    comparison_options = {"前年比": "yoy", "対前期比": "previous_period"}
+
+    with st.container():
+        cols = st.columns(4)
+        channel_choice = cols[0].selectbox(
+            "チャネル",
+            channel_options,
+            index=channel_options.index(
+                state.get("channel", transformers.ALL_CHANNELS)
+            ),
+        )
+        granularity_label = cols[1].selectbox(
+            "粒度",
+            list(granularity_options.keys()),
+            index=list(granularity_options.values()).index(
+                state.get("granularity", "monthly")
+            ),
+        )
+        breakdown_label = cols[2].selectbox(
+            "表示単位",
+            list(breakdown_options.keys()),
+            index=list(breakdown_options.values()).index(
+                state.get("breakdown", "store")
+            ),
+        )
+        comparison_label = cols[3].selectbox(
+            "比較",
+            list(comparison_options.keys()),
+            index=list(comparison_options.values()).index(
+                state.get("comparison", comparison_mode)
+            ),
+        )
+
+    state.update(
+        {
+            "channel": channel_choice,
+            "granularity": granularity_options[granularity_label],
+            "breakdown": breakdown_options[breakdown_label],
+            "comparison": comparison_options[comparison_label],
+        }
+    )
+
+    view_filters = transformers.FilterState(
+        stores=list(filters.stores),
+        start_date=filters.start_date,
+        end_date=filters.end_date,
+        categories=list(filters.categories),
+        regions=list(filters.regions),
+        channels=(
+            list(channels)
+            if channel_choice == transformers.ALL_CHANNELS
+            else [channel_choice]
+        ),
+        period_granularity=state["granularity"],
+        breakdown_dimension=state["breakdown"],
+    )
+
+    filtered_sales = transformers.apply_filters(sales_df, view_filters)
+    comparison_sales = _comparison_dataset(
+        sales_df, view_filters, state["comparison"]
+    )
+
     if filtered_sales.empty:
         st.info("該当データがありません")
         return
 
     kpis = sales.kpi_summary(filtered_sales, comparison_sales)
-    col1, col2, col3, col4, col5 = st.columns(5)
-    yoy_delta = (
-        f"{kpis['yoy_rate']*100:.1f}%" if kpis["yoy_rate"] is not None else None
+    total_customers = float(kpis["total_customers"])
+    previous_customers = (
+        float(comparison_sales["sales_qty"].sum())
+        if not comparison_sales.empty
+        else None
     )
-    col1.metric(
-        "期間売上",
-        f"{kpis['total_sales']:,.0f} 円",
-        yoy_delta,
+    avg_unit_price = float(kpis["avg_unit_price"])
+    previous_avg_price = None
+    if previous_customers and previous_customers > 0:
+        prev_sales_amount = float(comparison_sales["sales_amount"].sum())
+        previous_avg_price = (
+            prev_sales_amount / previous_customers if prev_sales_amount else 0.0
+        )
+
+    sales_target = (
+        float(comparison_sales["sales_amount"].sum()) * 1.05
+        if not comparison_sales.empty
+        else float(kpis["total_sales"]) * 1.05
     )
-    col2.metric("粗利", f"{kpis['total_gross_profit']:,.0f} 円")
-    col3.metric("平均客単価", f"{kpis['avg_unit_price']:,.0f} 円")
-    col4.metric("来客数(販売数量)", f"{kpis['total_customers']:,.0f}")
-    col5.metric("粗利率", f"{kpis['gross_margin']*100:.1f}%")
+    customer_target = (
+        previous_customers * 1.03 if previous_customers else total_customers
+    )
+    unit_price_target = (
+        previous_avg_price * 1.02 if previous_avg_price else avg_unit_price
+    )
 
-    granularity = filters.period_granularity
-    breakdown_column = sales.resolve_breakdown_column(filters.breakdown_dimension)
-    breakdown_label = sales.breakdown_label(filters.breakdown_dimension)
-    if breakdown_column is None:
-        breakdown_label = "全体"
+    _render_kpi_cards(
+        [
+            {
+                "label": "月次売上",
+                "value_text": _format_currency(kpis["total_sales"]),
+                "unit": "円",
+                "yoy": kpis.get("yoy_rate"),
+                "target_diff": kpis["total_sales"] - sales_target,
+            },
+            {
+                "label": "来客数",
+                "value_text": _format_number(total_customers, "人"),
+                "unit": "人",
+                "yoy": _compute_growth(total_customers, previous_customers),
+                "target_diff": total_customers - customer_target,
+            },
+            {
+                "label": "客単価",
+                "value_text": _format_currency(avg_unit_price),
+                "unit": "円",
+                "yoy": _compute_growth(avg_unit_price, previous_avg_price),
+                "target_diff": avg_unit_price - unit_price_target,
+            },
+        ]
+    )
 
+    breakdown_column = sales.resolve_breakdown_column(
+        view_filters.breakdown_dimension
+    )
+    breakdown_label = sales.breakdown_label(view_filters.breakdown_dimension)
     timeseries_df = sales.timeseries_with_comparison(
-        filtered_sales, comparison_sales, granularity, breakdown_column
-    )
-    custom_data = ["period_key"]
-    if breakdown_column:
-        custom_data.append(breakdown_column)
-
-    st.subheader(
-        f"{sales.granularity_label(granularity)}売上推移（{breakdown_label}）"
+        filtered_sales,
+        comparison_sales,
+        view_filters.period_granularity,
+        breakdown_column,
     )
     timeseries_chart = px.line(
         timeseries_df,
@@ -314,215 +956,152 @@ def render_sales_tab(
         color=breakdown_column if breakdown_column else None,
         markers=True,
         labels={"period_label": "期間", "sales_amount": "売上"},
-        custom_data=custom_data,
     )
-    timeseries_chart.update_layout(
-        hovermode="x unified",
-        clickmode="event+select",
-        yaxis_title="売上",
-        xaxis_title="期間",
-        legend_title=breakdown_label if breakdown_column else None,
+    if timeseries_df["comparison_sales"].notna().any():
+        timeseries_chart.add_trace(
+            go.Scatter(
+                x=timeseries_df["period_label"],
+                y=timeseries_df["comparison_sales"],
+                name="比較期間",
+                mode="lines+markers",
+                line=dict(dash="dash"),
+            )
+        )
+    st.subheader(f"売上推移（{breakdown_label}）")
+    st.plotly_chart(timeseries_chart, use_container_width=True)
+
+    st.subheader("チャネル別構成比")
+    composition_df = (
+        filtered_sales.groupby("channel")["sales_amount"].sum().reset_index()
     )
-    timeseries_chart.update_traces(mode="lines+markers")
-    selection = plotly_events(
-        timeseries_chart,
-        click_event=True,
-        select_event=True,
-        key=f"sales-timeseries-{granularity}-{breakdown_column or 'total'}",
-    )
-    st.caption("グラフをクリックすると該当期間の明細が表示されます。")
-
-    def _highlight_growth(value: float) -> str:
-        if pd.isna(value):
-            return ""
-        return "background-color: #ffe5e5" if value < 0 else "background-color: #e6f4ea"
-
-    summary_columns = [
-        "period_label",
-        "sales_amount",
-        "gross_profit",
-        "gross_margin",
-        "comparison_sales",
-        "comparison_gross_profit",
-        "comparison_margin",
-        "yoy_rate",
-        "gross_profit_yoy",
-        "margin_delta",
-    ]
-    if breakdown_column:
-        summary_columns.insert(1, breakdown_column)
-    summary_columns = [col for col in summary_columns if col in timeseries_df.columns]
-    summary_table = timeseries_df[summary_columns].copy()
-
-    rename_map = {
-        "period_label": "期間",
-        "sales_amount": "売上",
-        "gross_profit": "粗利",
-        "gross_margin": "粗利率",
-        "comparison_sales": "前年同期売上",
-        "comparison_gross_profit": "前年同期粗利",
-        "comparison_margin": "前年粗利率",
-        "yoy_rate": "売上前年比",
-        "gross_profit_yoy": "粗利前年比",
-        "margin_delta": "粗利率差",
-    }
-    if breakdown_column:
-        rename_map[breakdown_column] = breakdown_label.replace("別", "")
-    rename_map = {k: v for k, v in rename_map.items() if k in summary_table.columns}
-    summary_table = summary_table.rename(columns=rename_map)
-
-    format_map = {
-        "売上": "{:,.0f}",
-        "粗利": "{:,.0f}",
-        "粗利率": "{:.1%}",
-        "前年同期売上": "{:,.0f}",
-        "前年同期粗利": "{:,.0f}",
-        "前年粗利率": "{:.1%}",
-        "売上前年比": "{:+.1%}",
-        "粗利前年比": "{:+.1%}",
-        "粗利率差": "{:+.1%}",
-    }
-    summary_formatter = {
-        column: fmt for column, fmt in format_map.items() if column in summary_table.columns
-    }
-    summary_styler = summary_table.style.format(summary_formatter)
-    highlight_cols = [
-        column for column in ["売上前年比", "粗利前年比", "粗利率差"] if column in summary_table.columns
-    ]
-    if highlight_cols:
-        summary_styler = summary_styler.applymap(_highlight_growth, subset=highlight_cols)
-    st.dataframe(summary_styler, use_container_width=True)
-
-    drilldown_df = sales.drilldown_details(
-        filtered_sales, selection, granularity, breakdown_column
-    )
-    if not drilldown_df.empty:
-        st.subheader("ドリルダウン詳細")
-        detail_format = {
-            column: fmt
-            for column, fmt in {
-                "売上": "{:,.0f}",
-                "粗利": "{:,.0f}",
-                "粗利率": "{:.1%}",
-                "販売数量": "{:,.1f}",
-            }.items()
-            if column in drilldown_df.columns
-        }
+    if not composition_df.empty:
+        composition_df["構成比"] = (
+            composition_df["sales_amount"] / composition_df["sales_amount"].sum()
+        )
+        pie = px.pie(
+            composition_df,
+            names="channel",
+            values="sales_amount",
+            hole=0.35,
+        )
+        st.plotly_chart(pie, use_container_width=True)
         st.dataframe(
-            drilldown_df.style.format(detail_format),
+            composition_df.rename(
+                columns={"channel": "チャネル", "sales_amount": "売上"}
+            )
+            .assign(構成比=lambda df: df["構成比"].map(lambda v: f"{v*100:.1f}%")),
             use_container_width=True,
         )
 
-    breakdown_target = breakdown_column or "store"
-    summary_df = sales.breakdown_summary(
-        filtered_sales, comparison_sales, breakdown_target
-    )
-    if not summary_df.empty:
-        dimension_col = sales.resolve_breakdown_column(breakdown_target) or breakdown_target
-        summary_label = sales.breakdown_label(breakdown_target)
-        st.subheader(f"{summary_label}比較")
-        comparison_chart = go.Figure()
-        comparison_chart.add_bar(
-            x=summary_df[dimension_col],
-            y=summary_df["sales_amount"],
-            name="売上",
-        )
-        if summary_df["comparison_sales"].notna().any():
-            comparison_chart.add_bar(
-                x=summary_df[dimension_col],
-                y=summary_df["comparison_sales"],
-                name="前年同期売上",
-                opacity=0.7,
-            )
-        comparison_chart.add_trace(
-            go.Scatter(
-                x=summary_df[dimension_col],
-                y=summary_df["gross_margin"] * 100,
-                name="粗利率",
-                mode="lines+markers",
-                yaxis="y2",
-            )
-        )
-        if summary_df["comparison_margin"].notna().any():
-            comparison_chart.add_trace(
-                go.Scatter(
-                    x=summary_df[dimension_col],
-                    y=summary_df["comparison_margin"] * 100,
-                    name="前年粗利率",
-                    mode="lines+markers",
-                    line=dict(dash="dash"),
-                    yaxis="y2",
-                )
-            )
-        comparison_chart.update_layout(
-            hovermode="x unified",
-            barmode="group",
-            legend_title=summary_label,
-            yaxis=dict(title="売上"),
-            yaxis2=dict(
-                title="粗利率(%)",
-                overlaying="y",
-                side="right",
-                ticksuffix="%",
-            ),
-        )
-        st.plotly_chart(comparison_chart, use_container_width=True)
-
-        dimension_label = summary_label.replace("別", "")
-        table_columns = [
-            dimension_col,
+    st.subheader("売上明細")
+    details = filtered_sales[
+        [
+            "date",
+            "store",
+            "channel",
+            "category",
+            "product",
             "sales_amount",
+            "sales_qty",
             "gross_profit",
             "gross_margin",
-            "comparison_sales",
-            "comparison_gross_profit",
-            "comparison_margin",
-            "yoy_rate",
-            "gross_profit_yoy",
-            "margin_delta",
         ]
-        table_columns = [col for col in table_columns if col in summary_df.columns]
-        dimension_table = summary_df[table_columns].copy()
-        rename_map = {
-            dimension_col: dimension_label,
-            "sales_amount": "売上",
-            "gross_profit": "粗利",
-            "gross_margin": "粗利率",
-            "comparison_sales": "前年同期売上",
-            "comparison_gross_profit": "前年同期粗利",
-            "comparison_margin": "前年粗利率",
-            "yoy_rate": "売上前年比",
-            "gross_profit_yoy": "粗利前年比",
-            "margin_delta": "粗利率差",
-        }
-        rename_map = {k: v for k, v in rename_map.items() if k in dimension_table.columns}
-        dimension_table = dimension_table.rename(columns=rename_map)
-        dimension_formatter = {
-            column: fmt for column, fmt in format_map.items() if column in dimension_table.columns
-        }
-        dimension_styler = dimension_table.style.format(dimension_formatter)
-        highlight_cols = [
-            column for column in ["売上前年比", "粗利前年比", "粗利率差"] if column in dimension_table.columns
-        ]
-        if highlight_cols:
-            dimension_styler = dimension_styler.applymap(
-                _highlight_growth, subset=highlight_cols
-            )
-        st.dataframe(dimension_styler, use_container_width=True)
-    else:
-        st.info("選択した条件に該当する集計データがありません。")
+    ].copy()
+    details = details.sort_values("date", ascending=False)
+    st.dataframe(
+        details.style.format(
+            {
+                "sales_amount": "{:,.0f}",
+                "sales_qty": "{:,.1f}",
+                "gross_profit": "{:,.0f}",
+                "gross_margin": "{:.1%}",
+            }
+        ),
+        use_container_width=True,
+    )
 
+    report.csv_download(
+        "売上データをCSV出力",
+        details,
+        file_name=f"matsuya_sales_{filters.start_date:%Y%m%d}_{filters.end_date:%Y%m%d}.csv",
+    )
+    report.pdf_download(
+        "売上データをPDF出力",
+        "売上サマリー",
+        details,
+        file_name=f"matsuya_sales_{filters.start_date:%Y%m%d}.pdf",
+    )
 
 def render_products_tab(
-    filtered_sales: pd.DataFrame,
+    sales_df: pd.DataFrame,
     comparison_sales: pd.DataFrame,
+    filters: transformers.FilterState,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
-    st.subheader("ABC分析")
-    abc_df = products.abc_analysis(filtered_sales, comparison_sales)
-    if abc_df.empty:
+    st.markdown("### 商品分析")
+
+    category_options = sorted(sales_df["category"].dropna().unique().tolist())
+    category_choices = [transformers.ALL_CATEGORIES, *category_options]
+    state = st.session_state.setdefault(
+        "products_tab_state",
+        {"category": transformers.ALL_CATEGORIES},
+    )
+    selected_category = st.selectbox(
+        "カテゴリ",
+        category_choices,
+        index=category_choices.index(state.get("category", transformers.ALL_CATEGORIES))
+        if state.get("category", transformers.ALL_CATEGORIES) in category_choices
+        else 0,
+    )
+    state["category"] = selected_category
+
+    working_sales = sales_df.copy()
+    working_comparison = comparison_sales.copy()
+    if selected_category != transformers.ALL_CATEGORIES:
+        working_sales = working_sales[working_sales["category"] == selected_category]
+        if not working_comparison.empty:
+            working_comparison = working_comparison[
+                working_comparison["category"] == selected_category
+            ]
+
+    if working_sales.empty:
         st.info("該当データがありません")
+        return working_sales, working_comparison
+
+    aggregated = (
+        working_sales.groupby("product")["sales_amount"].sum().reset_index()
+    ).sort_values("sales_amount", ascending=False)
+    top5 = aggregated.head(5)
+    total_sales = float(working_sales["sales_amount"].sum())
+    top5_sales = float(top5["sales_amount"].sum())
+    previous_top5 = None
+    if not working_comparison.empty:
+        previous_agg = (
+            working_comparison.groupby("product")["sales_amount"].sum().reset_index()
+        ).sort_values("sales_amount", ascending=False)
+        previous_top5 = float(previous_agg.head(5)["sales_amount"].sum())
+
+    share = top5_sales / total_sales if total_sales else 0.0
+    target_share = 0.6
+    target_value = total_sales * target_share
+
+    _render_kpi_cards(
+        [
+            {
+                "label": "トップ5売上/構成比",
+                "value_text": f"{top5_sales:,.0f} 円 / {share*100:.1f}%",
+                "unit": "円",
+                "yoy": _compute_growth(top5_sales, previous_top5),
+                "target_diff": top5_sales - target_value,
+            }
+        ]
+    )
+
+    abc_df = products.abc_analysis(working_sales, working_comparison)
+    if abc_df.empty:
+        st.info("ABC分析を実行できません")
         return abc_df, abc_df
 
+    st.subheader("ABC分析チャート")
     pareto_df = products.pareto_chart_data(abc_df)
     pareto_chart = go.Figure()
     pareto_chart.add_bar(
@@ -564,28 +1143,120 @@ def render_products_tab(
                 f"{row['sales_amount']:,.0f} 円",
                 f"{row['yoy_growth']*100:.1f}%",
             )
+
+    st.subheader("商品明細")
+    detail_df = working_sales[
+        [
+            "date",
+            "store",
+            "category",
+            "product",
+            "sales_amount",
+            "sales_qty",
+            "gross_profit",
+        ]
+    ].copy()
+    detail_df = detail_df.sort_values("sales_amount", ascending=False)
+    st.dataframe(
+        detail_df.style.format(
+            {
+                "sales_amount": "{:,.0f}",
+                "sales_qty": "{:,.1f}",
+                "gross_profit": "{:,.0f}",
+            }
+        ),
+        use_container_width=True,
+    )
     return abc_df, top_growth
 
-
 def render_profitability_tab(
-    filtered_sales: pd.DataFrame,
+    sales_df: pd.DataFrame,
+    comparison_sales: pd.DataFrame,
     fixed_costs_df: pd.DataFrame,
+    filters: transformers.FilterState,
+    *,
+    navigate: Optional[Callable[[str], None]] = None,
 ) -> pd.DataFrame:
-    st.subheader("固定費内訳調整")
-    editable = fixed_costs_df.set_index("store")
-    edited = st.data_editor(
-        editable,
-        num_rows="dynamic",
-        use_container_width=True,
-        key="fixed_cost_editor",
-    )
-    edited_df = edited.reset_index()
+    st.markdown("### 利益管理")
+
     cost_columns = ["rent", "payroll", "utilities", "marketing", "other_fixed"]
+    adjusted = st.session_state.get("adjusted_fixed_costs")
+    base_costs = fixed_costs_df.copy()
+    if adjusted is not None:
+        base_costs = pd.DataFrame(adjusted)
+    editable = base_costs.set_index("store") if "store" in base_costs.columns else base_costs
+
+    with st.expander("固定費内訳調整", expanded=False):
+        edited = st.data_editor(
+            editable,
+            num_rows="dynamic",
+            use_container_width=True,
+            key="fixed_cost_editor",
+        )
+    edited_df = edited.reset_index() if "store" in edited.index.names else edited
     for col in cost_columns:
-        edited_df[col] = pd.to_numeric(edited_df[col], errors="coerce").fillna(0)
+        if col in edited_df:
+            edited_df[col] = pd.to_numeric(edited_df[col], errors="coerce").fillna(0)
+    st.session_state["adjusted_fixed_costs"] = edited_df.to_dict(orient="list")
+
+    pnl_df = profitability.store_profitability(sales_df, edited_df)
+    comparison_pnl = (
+        profitability.store_profitability(comparison_sales, edited_df)
+        if not comparison_sales.empty
+        else pd.DataFrame(columns=pnl_df.columns)
+    )
+
+    total_sales = float(pnl_df["sales_amount"].sum())
+    gross_profit = float(pnl_df["gross_profit"].sum())
+    operating_profit = float(pnl_df["operating_profit"].sum())
+    gross_margin = gross_profit / total_sales if total_sales else 0.0
+
+    previous_operating = (
+        float(comparison_pnl["operating_profit"].sum())
+        if not comparison_pnl.empty
+        else None
+    )
+    previous_gross = (
+        float(comparison_pnl["gross_profit"].sum())
+        if not comparison_pnl.empty
+        else None
+    )
+    previous_sales_total = (
+        float(comparison_pnl["sales_amount"].sum())
+        if not comparison_pnl.empty
+        else None
+    )
+    previous_margin = (
+        previous_gross / previous_sales_total if previous_sales_total else None
+    )
+
+    _render_kpi_cards(
+        [
+            {
+                "label": "粗利",
+                "value_text": _format_currency(gross_profit),
+                "unit": "円",
+                "yoy": _compute_growth(gross_profit, previous_gross),
+                "target_diff": gross_profit - total_sales * TARGET_MARGIN_RATE,
+            },
+                {
+                    "label": "粗利率",
+                    "value_text": f"{gross_margin*100:.1f}%",
+                    "unit": "%",
+                    "yoy": _compute_growth(gross_margin, previous_margin),
+                    "target_diff": (gross_margin - TARGET_MARGIN_RATE) * 100,
+                },
+            {
+                "label": "営業利益",
+                "value_text": _format_currency(operating_profit),
+                "unit": "円",
+                "yoy": _compute_growth(operating_profit, previous_operating),
+                "target_diff": operating_profit - total_sales * TARGET_MARGIN_RATE,
+            },
+        ]
+    )
 
     st.subheader("店舗別損益表")
-    pnl_df = profitability.store_profitability(filtered_sales, edited_df)
     styled = pnl_df.style.format(
         {
             "sales_amount": "{:,.0f}",
@@ -616,32 +1287,116 @@ def render_profitability_tab(
         labels={"value": "金額", "variable": "指標"},
     )
     st.plotly_chart(chart, use_container_width=True)
+
+    if navigate is not None:
+        st.info("シミュレーションで目標利益を検討できます。")
+        if st.button("シミュレーションを開く", key="profit_to_sim"):
+            navigate("simulation")
+
     return pnl_df
 
-
 def render_inventory_tab(
-    filtered_sales: pd.DataFrame,
+    sales_df: pd.DataFrame,
     inventory_df: pd.DataFrame,
-    abc_df: pd.DataFrame,
+    abc_df: Optional[pd.DataFrame],
     filters: transformers.FilterState,
 ) -> None:
-    st.subheader("在庫推定とアドバイス")
-    if filters.store != transformers.ALL_STORES:
-        inventory_df = inventory_df[inventory_df["store"] == filters.store]
-    if filters.category != transformers.ALL_CATEGORIES:
-        inventory_df = inventory_df[inventory_df["category"] == filters.category]
-    overview_df = inventory.inventory_overview(filtered_sales, inventory_df)
+    st.markdown("### 在庫分析")
+
+    store_options = sorted(inventory_df["store"].dropna().unique().tolist())
+    category_options = sorted(inventory_df["category"].dropna().unique().tolist())
+    store_choices = [transformers.ALL_STORES, *store_options]
+    category_choices = [transformers.ALL_CATEGORIES, *category_options]
+
+    state = st.session_state.setdefault(
+        "inventory_tab_state",
+        {
+            "store": filters.store,
+            "category": filters.category,
+        },
+    )
+    with st.container():
+        col1, col2 = st.columns(2)
+        store_choice = col1.selectbox(
+            "店舗",
+            store_choices,
+            index=store_choices.index(state.get("store", store_choices[0]))
+            if state.get("store") in store_choices
+            else 0,
+        )
+        category_choice = col2.selectbox(
+            "カテゴリ",
+            category_choices,
+            index=category_choices.index(state.get("category", category_choices[0]))
+            if state.get("category") in category_choices
+            else 0,
+        )
+    state.update({"store": store_choice, "category": category_choice})
+
+    working_sales = sales_df.copy()
+    working_inventory = inventory_df.copy()
+    if store_choice != transformers.ALL_STORES:
+        working_sales = working_sales[working_sales["store"] == store_choice]
+        working_inventory = working_inventory[working_inventory["store"] == store_choice]
+    if category_choice != transformers.ALL_CATEGORIES:
+        working_sales = working_sales[working_sales["category"] == category_choice]
+        working_inventory = working_inventory[working_inventory["category"] == category_choice]
+
+    overview_df = inventory.inventory_overview(working_sales, working_inventory)
     if overview_df.empty:
         st.info("在庫データが見つかりません。")
         return
-    rank_lookup = dict(zip(abc_df["product"], abc_df.get("rank", [])))
+
+    rank_lookup: Dict[str, str] = {}
+    if abc_df is not None and not abc_df.empty:
+        filtered_abc = abc_df.copy()
+        if store_choice != transformers.ALL_STORES and "store" in filtered_abc.columns:
+            filtered_abc = filtered_abc[filtered_abc.get("store") == store_choice]
+        if category_choice != transformers.ALL_CATEGORIES:
+            filtered_abc = filtered_abc[filtered_abc.get("category") == category_choice]
+        if "product" in filtered_abc.columns:
+            rank_lookup = dict(zip(filtered_abc["product"], filtered_abc.get("rank", [])))
+
     advice_df = inventory.inventory_advice(overview_df, rank_lookup)
+
+    safety_excess = int((advice_df["stock_status"] == "在庫過多").sum())
+    stockouts = int((advice_df["stock_status"] == "在庫切れ").sum())
+    period_days = max((filters.end_date - filters.start_date).days + 1, 1)
+    turnover_df = inventory.turnover_by_category(overview_df, period_days=period_days)
+    avg_turnover = float(turnover_df["turnover"].mean()) if not turnover_df.empty else 0.0
+
+    _render_kpi_cards(
+        [
+            {
+                "label": "安全在庫超過数",
+                "value_text": _format_number(safety_excess, "品目"),
+                "unit": "品目",
+                "yoy": None,
+                "target_diff": -safety_excess,
+            },
+            {
+                "label": "欠品数",
+                "value_text": _format_number(stockouts, "品目"),
+                "unit": "品目",
+                "yoy": None,
+                "target_diff": -stockouts,
+            },
+                {
+                    "label": "平均在庫回転率",
+                    "value_text": f"{avg_turnover:.1f} 回",
+                    "unit": "回",
+                    "yoy": None,
+                    "target_diff": avg_turnover - 8,
+                },
+        ]
+    )
+
+    st.subheader("在庫推定とアドバイス")
     st.dataframe(advice_df, use_container_width=True)
 
-    period_days = (filters.end_date - filters.start_date).days + 1
-    turnover_df = inventory.turnover_by_category(overview_df, period_days=period_days)
     st.subheader("カテゴリ別在庫回転率")
     st.dataframe(turnover_df, use_container_width=True)
+
     heatmap = px.density_heatmap(
         advice_df,
         x="category",
@@ -651,8 +1406,6 @@ def render_inventory_tab(
         labels={"estimated_stock": "推定在庫"},
     )
     st.plotly_chart(heatmap, use_container_width=True)
-
-
 def render_simulation_tab(
     pnl_df: pd.DataFrame,
     filters: transformers.FilterState,
@@ -714,8 +1467,10 @@ def render_simulation_tab(
         )
 
 
+
 def main() -> None:
     st.title("松屋 計数管理ダッシュボード")
+    _inject_global_styles()
 
     sample_files = data_loader.available_sample_files()
     templates = data_loader.available_templates()
@@ -743,6 +1498,7 @@ def main() -> None:
         sample_files={k: str(v) for k, v in sample_files.items()},
         templates=templates,
         providers=provider_options,
+        show_filters=False,
     )
 
     mode = sidebar_state["data_source_mode"]
@@ -773,56 +1529,87 @@ def main() -> None:
     st.session_state["current_datasets"] = _copy_datasets(datasets)
     st.session_state["current_source"] = mode
 
-    filters = sidebar_state["filters"]
-    filtered_sales = transformers.apply_filters(datasets["sales"], filters)
-    comparison_mode = sidebar_state["comparison_mode"]
-    comparison_sales = _comparison_dataset(datasets["sales"], filters, comparison_mode)
-
-    tabs = st.tabs(
-        [
-            "売上分析",
-            "商品別分析",
-            "損益管理",
-            "在庫分析",
-            "経営シミュレーション",
-            "データ取込管理",
-        ]
+    bounds = _dataset_bounds(datasets["sales"])
+    global_filters = render_global_filter_bar(
+        stores,
+        categories,
+        default_period=default_period,
+        bounds=bounds,
     )
 
-    with tabs[0]:
-        render_sales_tab(filtered_sales, comparison_sales, filters)
+    filtered_sales = transformers.apply_filters(datasets["sales"], global_filters)
+    dashboard_comparison = _comparison_dataset(
+        datasets["sales"], global_filters, "previous_period"
+    )
 
-    with tabs[1]:
-        abc_df, _ = render_products_tab(filtered_sales, comparison_sales)
+    def _navigate(tab_key: str) -> None:
+        st.session_state[NAV_STATE_KEY] = tab_key
+        st.experimental_rerun()
 
-    with tabs[2]:
-        pnl_df = render_profitability_tab(filtered_sales, datasets["fixed_costs"])
+    tab_labels = [label for _, label in MAIN_TAB_CONFIG]
+    current_tab = st.session_state.get(NAV_STATE_KEY, DEFAULT_NAV_KEY)
+    current_index = next(
+        (idx for idx, (key, _) in enumerate(MAIN_TAB_CONFIG) if key == current_tab),
+        0,
+    )
+    selected_label = st.radio(
+        "画面切替",
+        tab_labels,
+        index=current_index,
+        horizontal=True,
+        label_visibility="collapsed",
+    )
+    selected_key = next(
+        key for key, label in MAIN_TAB_CONFIG if label == selected_label
+    )
+    st.session_state[NAV_STATE_KEY] = selected_key
 
-    with tabs[3]:
-        render_inventory_tab(filtered_sales, datasets["inventory"], abc_df, filters)
+    pnl_baseline = profitability.store_profitability(
+        filtered_sales,
+        datasets["fixed_costs"],
+    )
 
-    with tabs[4]:
-        render_simulation_tab(pnl_df, filters)
-
-    with tabs[5]:
+    if selected_key == "dashboard":
+        pnl_df = render_dashboard_tab(
+            filtered_sales,
+            dashboard_comparison,
+            global_filters,
+            datasets["fixed_costs"],
+            datasets["inventory"],
+            navigate=_navigate,
+        )
+        st.session_state["latest_pnl_df"] = pnl_df
+    elif selected_key == "sales":
+        render_sales_tab(
+            datasets["sales"],
+            global_filters,
+            channels,
+            comparison_mode="yoy",
+        )
+    elif selected_key == "product":
+        abc_df, _ = render_products_tab(filtered_sales, dashboard_comparison, global_filters)
+        st.session_state["latest_abc_df"] = abc_df
+    elif selected_key == "profit":
+        pnl_df = render_profitability_tab(
+            filtered_sales,
+            dashboard_comparison,
+            datasets["fixed_costs"],
+            global_filters,
+            navigate=_navigate,
+        )
+        st.session_state["latest_pnl_df"] = pnl_df
+    elif selected_key == "inventory":
+        abc_df = st.session_state.get("latest_abc_df")
+        if abc_df is None:
+            abc_df = products.abc_analysis(filtered_sales, dashboard_comparison)
+            st.session_state["latest_abc_df"] = abc_df
+        render_inventory_tab(filtered_sales, datasets["inventory"], abc_df, global_filters)
+    elif selected_key == "simulation":
+        pnl_df = st.session_state.get("latest_pnl_df", pnl_baseline)
+        render_simulation_tab(pnl_df, global_filters)
+    else:
         integration_display = integration_result or st.session_state.get("latest_api_result")
         import_dashboard.render_dashboard(validation_results, integration_display)
-
-    with st.sidebar:
-        if sidebar_state["export_csv"]:
-            report.csv_download(
-                "売上データをCSV出力",
-                filtered_sales,
-                file_name=f"matsuya_sales_{filters.start_date:%Y%m%d}_{filters.end_date:%Y%m%d}.csv",
-            )
-        if sidebar_state["export_pdf"]:
-            report.pdf_download(
-                "売上データをPDF出力",
-                "売上サマリー",
-                filtered_sales[["date", "store", "category", "sales_amount", "gross_profit"]],
-                file_name=f"matsuya_sales_{filters.start_date:%Y%m%d}.pdf",
-            )
-
 
 if __name__ == "__main__":
     main()

--- a/streamlit_app/components/sidebar.py
+++ b/streamlit_app/components/sidebar.py
@@ -64,6 +64,7 @@ def render_sidebar(
     sample_files: Dict[str, str],
     templates: Dict[str, bytes],
     providers: List[str],
+    show_filters: bool = True,
 ) -> Dict[str, object]:
     st.sidebar.header("データソース")
     mode_label = st.sidebar.radio("連携方法", ["CSVアップロード", "API連携"])
@@ -136,55 +137,66 @@ def render_sidebar(
                 key=f"template-{key}",
             )
 
-    st.sidebar.header("フィルタ")
-    store_selection = st.sidebar.multiselect(
-        "店舗選択",
-        stores,
-        default=stores,
-    )
-    date_range_value = st.sidebar.date_input(
-        "期間選択",
-        value=default_period,
-    )
-    start_date, end_date = _resolve_date_range(date_range_value)
-    category_selection = st.sidebar.multiselect(
-        "商品カテゴリ",
-        categories,
-        default=categories,
-    )
-    region_selection: List[str] = []
-    if regions:
-        region_selection = st.sidebar.multiselect(
-            "地域",
-            regions,
-            default=regions,
-        )
-    channel_selection: List[str] = []
-    if channels:
-        channel_selection = st.sidebar.multiselect(
-            "販売チャネル",
-            channels,
-            default=channels,
-        )
-    comparison_label = st.sidebar.radio("比較モード", list(COMPARISON_OPTIONS.keys()))
+    export_csv = export_pdf = False
+    comparison_label = list(COMPARISON_OPTIONS.keys())[0]
+    period_label = list(PERIOD_OPTIONS.keys())[2]
+    breakdown_label = list(BREAKDOWN_OPTIONS.keys())[0]
+    store_selection = list(stores)
+    category_selection = list(categories)
+    region_selection: List[str] = list(regions)
+    channel_selection: List[str] = list(channels)
+    start_date, end_date = default_period
 
-    st.sidebar.header("集計設定")
-    period_label = st.sidebar.radio(
-        "期間粒度",
-        list(PERIOD_OPTIONS.keys()),
-        index=2,
-        horizontal=True,
-    )
-    breakdown_label = st.sidebar.radio(
-        "表示単位",
-        list(BREAKDOWN_OPTIONS.keys()),
-        horizontal=True,
-    )
+    if show_filters:
+        st.sidebar.header("フィルタ")
+        store_selection = st.sidebar.multiselect(
+            "店舗選択",
+            stores,
+            default=stores,
+        )
+        date_range_value = st.sidebar.date_input(
+            "期間選択",
+            value=default_period,
+        )
+        start_date, end_date = _resolve_date_range(date_range_value)
+        category_selection = st.sidebar.multiselect(
+            "商品カテゴリ",
+            categories,
+            default=categories,
+        )
+        region_selection = []
+        if regions:
+            region_selection = st.sidebar.multiselect(
+                "地域",
+                regions,
+                default=regions,
+            )
+        channel_selection = []
+        if channels:
+            channel_selection = st.sidebar.multiselect(
+                "販売チャネル",
+                channels,
+                default=channels,
+            )
+        comparison_label = st.sidebar.radio("比較モード", list(COMPARISON_OPTIONS.keys()))
 
-    st.sidebar.header("帳票出力")
-    export_csv = st.sidebar.checkbox("CSV出力", value=True)
-    export_pdf = st.sidebar.checkbox("PDF出力")
-    st.sidebar.markdown("---")
+        st.sidebar.header("集計設定")
+        period_label = st.sidebar.radio(
+            "期間粒度",
+            list(PERIOD_OPTIONS.keys()),
+            index=2,
+            horizontal=True,
+        )
+        breakdown_label = st.sidebar.radio(
+            "表示単位",
+            list(BREAKDOWN_OPTIONS.keys()),
+            horizontal=True,
+        )
+
+        st.sidebar.header("帳票出力")
+        export_csv = st.sidebar.checkbox("CSV出力", value=True)
+        export_pdf = st.sidebar.checkbox("PDF出力")
+        st.sidebar.markdown("---")
 
     filters = transformers.FilterState(
         stores=_ensure_selection(stores, store_selection),


### PR DESCRIPTION
## Summary
- introduce global styles, navigation state, and filter bar to centralise control across the dashboard
- build a dedicated executive dashboard plus refreshed sales, product, profitability, and inventory views with purpose-specific KPI cards and layouts
- update the sidebar component to make dataset controls available without duplicating filter inputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3eddd142483239f61fd5560f47bea