### PR TITLE
Fix previous period comparison filter construction

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -69,10 +69,14 @@ def _comparison_dataset(
         prev_end = filters.start_date - timedelta(days=1)
         prev_start = prev_end - timedelta(days=period_days - 1)
         comparison_filters = transformers.FilterState(
-            store=filters.store,
+            stores=list(filters.stores),
             start_date=prev_start,
             end_date=prev_end,
-            category=filters.category,
+            categories=list(filters.categories),
+            regions=list(filters.regions),
+            channels=list(filters.channels),
+            period_granularity=filters.period_granularity,
+            breakdown_dimension=filters.breakdown_dimension,
         )
         return transformers.apply_filters(df, comparison_filters)
     return df.head(0)


### PR DESCRIPTION
## Summary
- ensure the previous period comparison uses the correct FilterState fields when building filters
- include regions, channels, and aggregation metadata when computing the comparison dataset

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3f7eeff18832387ad4146e0ca52f9