### PR TITLE
Handle leap day in YoY comparison period

### DIFF
--- a/streamlit_app/transformers.py
+++ b/streamlit_app/transformers.py
@@ -166,8 +166,10 @@ def extract_channels(df: pd.DataFrame) -> List[str]:
 
 def compute_comparison_period(filters: FilterState) -> FilterState:
     """Return the comparison period (one year earlier) for YoY calculations."""
-    start_prev = filters.start_date.replace(year=filters.start_date.year - 1)
-    end_prev = filters.end_date.replace(year=filters.end_date.year - 1)
+    start_prev = (
+        pd.Timestamp(filters.start_date) - pd.DateOffset(years=1)
+    ).date()
+    end_prev = (pd.Timestamp(filters.end_date) - pd.DateOffset(years=1)).date()
     return FilterState(
         stores=list(filters.stores),
         start_date=start_prev,

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -1,0 +1,25 @@
+from datetime import date
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from streamlit_app.transformers import FilterState, compute_comparison_period
+
+
+def test_compute_comparison_period_handles_leap_year():
+    filters = FilterState(
+        stores=["本店"],
+        start_date=date(2024, 2, 29),
+        end_date=date(2024, 2, 29),
+        categories=["ケーキ"],
+    )
+
+    comparison_filters = compute_comparison_period(filters)
+
+    assert comparison_filters.start_date == date(2023, 2, 28)
+    assert comparison_filters.end_date == date(2023, 2, 28)
+    assert comparison_filters.stores == list(filters.stores)
+    assert comparison_filters.categories == list(filters.categories)
+    assert comparison_filters.period_granularity == filters.period_granularity
+    assert comparison_filters.breakdown_dimension == filters.breakdown_dimension


### PR DESCRIPTION
## Summary
- compute the year-over-year comparison window with pandas DateOffset to avoid invalid leap-day dates
- add a regression test ensuring a 2024-02-29 filter produces a valid comparison period

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d49c9eece08323b3cf10df36273adc