### PR TITLE
Fix duplicate widget IDs on inventory tab

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -2145,6 +2145,7 @@ def render_inventory_tab(
             index=store_choices.index(state.get("store", store_choices[0]))
             if state.get("store") in store_choices
             else 0,
+            key="inventory_store_select",
         )
         category_choice = col2.selectbox(
             "カテゴリ",
@@ -2152,6 +2153,7 @@ def render_inventory_tab(
             index=category_choices.index(state.get("category", category_choices[0]))
             if state.get("category") in category_choices
             else 0,
+            key="inventory_category_select",
         )
     state.update({"store": store_choice, "category": category_choice})
 


### PR DESCRIPTION
## Summary
- assign explicit Streamlit keys to the store and category select boxes on the inventory tab
- prevent duplicate element id errors caused by the previous implicit keys

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d49ffaf8608323833d80b13ce2b249