### PR TITLE
Fix Streamlit session state sync

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -3176,7 +3176,6 @@ def main() -> None:
 
         active_tab = _render_analysis_navigation(active_tab)
         st.session_state[MAIN_TAB_KEY] = active_tab
-        st.session_state["sidebar_analysis_selector"] = active_tab
 
         if active_tab == "売上":
             render_sales_tab(


### PR DESCRIPTION
## Summary
- avoid programmatically writing to the `sidebar_analysis_selector` widget state to prevent Streamlit session state errors when switching navigation tabs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d51eaaa7fc8323abdc2f0169486e59