### PR TITLE
Enhance inventory analytics, alerting, and data management

### DIFF
--- a/streamlit_app/analytics/inventory.py
+++ b/streamlit_app/analytics/inventory.py
@@ -1,72 +1,202 @@
 """Inventory related analytics."""
 from __future__ import annotations
 
-from typing import Dict, Optional
+from datetime import date
+from typing import Dict, Optional, Tuple
 
 import pandas as pd
 
 
-def inventory_overview(sales: pd.DataFrame, inventory: pd.DataFrame) -> pd.DataFrame:
-    """Estimate closing inventory using sales consumption."""
-    sold = (
-        sales.groupby(["store", "product"])["sales_qty"]
+DEFAULT_ROLLING_WINDOW = 7
+DEFAULT_SAFETY_BUFFER_DAYS = 3
+
+
+def _resolve_date_range(
+    sales: pd.DataFrame, start: Optional[date], end: Optional[date]
+) -> Tuple[pd.Timestamp, pd.Timestamp]:
+    if start is not None and end is not None:
+        return pd.Timestamp(start), pd.Timestamp(end)
+    if sales.empty:
+        today = pd.Timestamp.today().normalize()
+        return today - pd.Timedelta(days=30), today
+    return sales["date"].min().normalize(), sales["date"].max().normalize()
+
+
+def inventory_overview(
+    sales: pd.DataFrame,
+    inventory: pd.DataFrame,
+    *,
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
+    rolling_window: int = DEFAULT_ROLLING_WINDOW,
+    safety_buffer_days: int = DEFAULT_SAFETY_BUFFER_DAYS,
+) -> pd.DataFrame:
+    """Estimate inventory KPIs using moving averages and sales cost."""
+
+    if inventory.empty:
+        return inventory.head(0)
+
+    working_sales = sales.copy()
+    if "date" in working_sales.columns:
+        working_sales["date"] = pd.to_datetime(working_sales["date"])  # ensure tz aware
+
+    window = max(int(rolling_window), 1)
+    buffer_days = max(int(safety_buffer_days), 0)
+
+    period_start, period_end = _resolve_date_range(working_sales, start_date, end_date)
+
+    daily_sales = (
+        working_sales.assign(date=working_sales["date"].dt.floor("D"))
+        .groupby(["store", "product", "date"], as_index=False)[
+            ["sales_qty", "cogs_amount"]
+        ]
         .sum()
-        .reset_index()
-        .rename(columns={"sales_qty": "sold_qty"})
     )
-    merged = inventory.merge(sold, on=["store", "product"], how="left")
-    merged["sold_qty"] = merged["sold_qty"].fillna(0)
-    merged["estimated_stock"] = (
-        merged["opening_stock"] + merged["planned_purchase"] - merged["sold_qty"]
-    )
-    merged["stock_status"] = "適正"
-    merged.loc[merged["estimated_stock"] <= 0, "stock_status"] = "在庫切れ"
-    merged.loc[
-        (merged["estimated_stock"] > 0)
-        & (merged["estimated_stock"] <= merged["safety_stock"] * 0.7),
-        "stock_status",
-    ] = "在庫少"
-    merged.loc[merged["estimated_stock"] > merged["safety_stock"] * 1.3, "stock_status"] = "在庫過多"
-    return merged
+
+    records = []
+    for _, row in inventory.iterrows():
+        store_name = row.get("store")
+        product_name = row.get("product")
+        opening = float(row.get("opening_stock", 0) or 0)
+        purchase = float(row.get("planned_purchase", 0) or 0)
+        safety_stock = float(row.get("safety_stock", 0) or 0)
+        available = max(opening + purchase, 0)
+
+        product_sales = daily_sales[
+            (daily_sales["store"] == store_name)
+            & (daily_sales["product"] == product_name)
+        ].copy()
+
+        timeline = pd.date_range(period_start, period_end, freq="D")
+        if product_sales.empty:
+            profile = pd.DataFrame(
+                {
+                    "date": timeline,
+                    "sales_qty": 0.0,
+                    "cogs_amount": 0.0,
+                }
+            )
+        else:
+            product_sales = product_sales.set_index("date").reindex(timeline, fill_value=0.0)
+            product_sales = product_sales.reset_index().rename(columns={"index": "date"})
+            profile = product_sales
+
+        profile = profile.sort_values("date")
+        profile["cumulative_qty"] = profile["sales_qty"].cumsum()
+        profile["estimated_stock"] = (available - profile["cumulative_qty"]).clip(lower=0.0)
+        profile["moving_stock"] = (
+            profile["estimated_stock"].rolling(window=window, min_periods=1).mean()
+        )
+        profile["moving_sales_qty"] = (
+            profile["sales_qty"].rolling(window=window, min_periods=1).mean()
+        )
+        profile["moving_cogs"] = (
+            profile["cogs_amount"].rolling(window=window, min_periods=1).mean()
+        )
+
+        avg_inventory = float(profile["moving_stock"].mean()) if not profile.empty else available
+        avg_inventory = max(avg_inventory, 0.0)
+        total_cogs = float(profile["cogs_amount"].sum())
+        total_sales_qty = float(profile["sales_qty"].sum())
+        avg_daily_qty = float(profile["moving_sales_qty"].iloc[-1]) if not profile.empty else 0.0
+        avg_daily_cogs = float(profile["moving_cogs"].iloc[-1]) if not profile.empty else 0.0
+        ending_stock = float(profile["estimated_stock"].iloc[-1]) if not profile.empty else available
+
+        turnover = total_cogs / avg_inventory if avg_inventory > 0 else 0.0
+        turnover = max(turnover, 0.0)
+
+        safety_lower = max(safety_stock - avg_daily_qty * buffer_days, 0.0)
+        safety_upper = safety_stock + avg_daily_qty * buffer_days
+        coverage_days = (ending_stock / avg_daily_qty) if avg_daily_qty > 0 else None
+
+        status = "適正"
+        if ending_stock <= 0:
+            status = "在庫切れ"
+        elif ending_stock <= max(safety_lower, safety_stock * 0.5):
+            status = "在庫少"
+        elif ending_stock >= safety_upper and safety_upper > 0:
+            status = "在庫過多"
+
+        records.append(
+            {
+                **row,
+                "sold_qty": total_sales_qty,
+                "estimated_stock": ending_stock,
+                "avg_inventory": avg_inventory,
+                "avg_daily_qty": avg_daily_qty,
+                "avg_daily_cogs": avg_daily_cogs,
+                "total_cogs": total_cogs,
+                "turnover": round(turnover, 2),
+                "safety_lower": safety_lower,
+                "safety_upper": safety_upper,
+                "coverage_days": coverage_days,
+                "stock_status": status,
+                "safety_buffer_days": buffer_days,
+                "analysis_window": window,
+            }
+        )
+
+    overview_df = pd.DataFrame(records)
+    if "coverage_days" in overview_df.columns:
+        overview_df["coverage_days"] = overview_df["coverage_days"].round(1)
+    return overview_df
 
 
 def turnover_by_category(overview: pd.DataFrame, *, period_days: int) -> pd.DataFrame:
-    """Calculate inventory turnover ratio per category."""
+    """Calculate inventory turnover ratio per category using COGS."""
+
+    if overview.empty:
+        return overview.head(0)
+
     if period_days <= 0:
         period_days = 1
+
     df = overview.copy()
-    df["avg_inventory"] = (df["opening_stock"] + df["estimated_stock"]) / 2
-    annualised_factor = 365 / period_days
-    df["turnover"] = (
-        df["sold_qty"].fillna(0) * annualised_factor
-    ) / df["avg_inventory"].replace(0, pd.NA)
-    df["turnover"] = df["turnover"].fillna(0.0)
-    return (
-        df.groupby("category")[["turnover", "avg_inventory"]]
-        .mean()
+    df["avg_inventory"] = df["avg_inventory"].replace(0, pd.NA)
+    df["category_turnover"] = (
+        df["total_cogs"].fillna(0) * (365 / period_days)
+    ) / df["avg_inventory"]
+    df["category_turnover"] = df["category_turnover"].fillna(0.0)
+
+    grouped = (
+        df.groupby("category")
+        .agg(
+            turnover=("category_turnover", "mean"),
+            avg_inventory=("avg_inventory", "mean"),
+            cogs=("total_cogs", "sum"),
+        )
         .reset_index()
-        .sort_values("turnover", ascending=False)
     )
+    grouped["turnover"] = grouped["turnover"].round(2)
+    return grouped.sort_values("turnover", ascending=False)
 
 
-def inventory_advice(overview: pd.DataFrame, rank_lookup: Optional[Dict[str, str]] = None) -> pd.DataFrame:
-    """Generate qualitative advice per product."""
+def inventory_advice(
+    overview: pd.DataFrame, rank_lookup: Optional[Dict[str, str]] = None
+) -> pd.DataFrame:
+    """Generate qualitative advice per product with lead time context."""
+
     def create_message(row: pd.Series) -> str:
         rank = None
         if rank_lookup:
             rank = rank_lookup.get(row["product"])
         status = row.get("stock_status", "")
+        lead = row.get("coverage_days")
+        lead_text = (
+            f"想定残日数は約{lead:.1f}日です。" if isinstance(lead, (int, float)) else ""
+        )
+
         if status == "在庫切れ":
             return "在庫が枯渇しています。即時の補充が必要です。"
         if status == "在庫少":
             if rank == "A":
-                return "主力商品の在庫が不足しています。優先的に補充してください。"
-            return "在庫が少ないため、次回仕入での補充を検討してください。"
+                return "主力商品の在庫が不足しています。優先的に補充してください。" + lead_text
+            return "在庫が少ないため、次回仕入での補充を検討してください。" + lead_text
         if status == "在庫過多":
             if rank == "C":
                 return "回転の遅い商品の過剰在庫です。販促や仕入抑制を検討。"
             return "在庫が多めです。販売動向をモニタリングしましょう。"
-        return "適正在庫を維持しています。"
+        return "適正在庫を維持しています。" + (" " + lead_text if lead_text else "")
 
     advice_df = overview.copy()
     advice_df["advice"] = advice_df.apply(create_message, axis=1)

--- a/streamlit_app/components/sidebar.py
+++ b/streamlit_app/components/sidebar.py
@@ -178,6 +178,9 @@ def render_sidebar(
             "stockout_threshold": 0,
             "excess_threshold": 5,
             "deficit_threshold": -500000,
+            "notification_channel": "banner",
+            "notification_email": "",
+            "slack_webhook": "",
         },
     )
     st.sidebar.header("アラート設定")
@@ -199,11 +202,30 @@ def render_sidebar(
         step=50000,
         format="%d",
     )
+    notification_mode = st.sidebar.selectbox(
+        "通知表示", ["ページ上部バナー", "モーダル"],
+        index=0 if alert_state.get("notification_channel", "banner") == "banner" else 1,
+    )
+    notification_email = st.sidebar.text_input(
+        "通知メールアドレス",
+        value=alert_state.get("notification_email", ""),
+        help="アラートをメール通知する場合に入力してください。",
+    )
+    slack_webhook = st.sidebar.text_input(
+        "Slack Webhook URL",
+        value=alert_state.get("slack_webhook", ""),
+        help="Slack通知に利用するIncoming WebhookのURLを登録します。",
+    )
     alert_state.update(
         {
             "stockout_threshold": int(stockout_threshold),
             "excess_threshold": int(excess_threshold),
             "deficit_threshold": float(deficit_threshold),
+            "notification_channel": "banner"
+            if notification_mode == "ページ上部バナー"
+            else "modal",
+            "notification_email": notification_email,
+            "slack_webhook": slack_webhook,
         }
     )
 


### PR DESCRIPTION
## Summary
- Refine inventory KPIs to use moving averages, safety buffers, and coverage days while updating the visualization to show safety bands and lead-time context.
- Add a configurable alert center with banner/modal delivery, optional email/Slack endpoints, and updated help guidance covering templates, notifications, and recommended environments.
- Rework the cash-flow simulation into a single form-driven workflow with preset targets, and extend the data management page with previews, anomaly checks, and category mapping.

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d53755c8b08323807e75184e2c4c4f