### PR TITLE
Enhance dashboard usability with wizard, KPI highlights, and reporting

### DIFF
--- a/streamlit_app/components/report.py
+++ b/streamlit_app/components/report.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 from io import BytesIO
+import textwrap
+from typing import Sequence, Tuple
+
 import pandas as pd
 import streamlit as st
 from reportlab.lib.pagesizes import A4
@@ -77,3 +80,109 @@ def create_pdf_report(title: str, df: pd.DataFrame) -> bytes:
     pdf.save()
     buffer.seek(0)
     return buffer.getvalue()
+
+
+def build_markdown_report(
+    title: str, sections: Sequence[Tuple[str, Sequence[str]]]
+) -> str:
+    """Build a Markdown report string from the provided sections."""
+
+    lines = [f"# {title}", ""]
+    for heading, contents in sections:
+        if heading:
+            lines.append(f"## {heading}")
+            lines.append("")
+        for paragraph in contents:
+            lines.append(paragraph)
+        lines.append("")
+    return "\n".join(lines).strip() + "\n"
+
+
+def create_text_pdf(title: str, sections: Sequence[Tuple[str, Sequence[str]]]) -> bytes:
+    """Create a simple text-centric PDF from Markdown-like content."""
+
+    _register_pdf_font()
+    buffer = BytesIO()
+    pdf = canvas.Canvas(buffer, pagesize=A4)
+    width, height = A4
+    margin = 40
+    y = height - margin
+
+    def _new_page() -> None:
+        nonlocal y
+        pdf.showPage()
+        pdf.setFont(PDF_FONT, 16)
+        y = height - margin
+        pdf.drawString(margin, y, title)
+        y -= 32
+
+    pdf.setFont(PDF_FONT, 16)
+    pdf.drawString(margin, y, title)
+    y -= 32
+
+    text_width = max(36, int((width - margin * 2) / 12))
+
+    for heading, contents in sections:
+        if heading:
+            if y < margin + 40:
+                _new_page()
+            pdf.setFont(PDF_FONT, 13)
+            pdf.drawString(margin, y, heading)
+            y -= 22
+        pdf.setFont(PDF_FONT, 11)
+        for paragraph in contents:
+            raw_lines = paragraph.splitlines() or [""]
+            for raw_line in raw_lines:
+                line = raw_line.rstrip()
+                is_bullet = line.strip().startswith("- ")
+                content = line.strip()[2:].strip() if is_bullet else line.strip()
+                if not content:
+                    if y < margin + 20:
+                        _new_page()
+                        if heading:
+                            pdf.setFont(PDF_FONT, 13)
+                            pdf.drawString(margin, y, heading)
+                            y -= 22
+                            pdf.setFont(PDF_FONT, 11)
+                    y -= 12
+                    continue
+                wrapped = textwrap.wrap(content, width=text_width) or [content]
+                for idx, wrapped_line in enumerate(wrapped):
+                    if y < margin + 20:
+                        _new_page()
+                        if heading:
+                            pdf.setFont(PDF_FONT, 13)
+                            pdf.drawString(margin, y, heading)
+                            y -= 22
+                            pdf.setFont(PDF_FONT, 11)
+                    prefix = "• " if is_bullet and idx == 0 else ("  " if is_bullet else "")
+                    pdf.drawString(margin, y, f"{prefix}{wrapped_line}")
+                    y -= 16
+                y -= 6
+        y -= 6
+
+    pdf.save()
+    buffer.seek(0)
+    return buffer.getvalue()
+
+
+def render_dashboard_report_downloads(
+    title: str, sections: Sequence[Tuple[str, Sequence[str]]], base_file_name: str
+) -> None:
+    """Render download buttons for Markdown/PDF dashboard reports."""
+
+    markdown = build_markdown_report(title, sections)
+    pdf_bytes = create_text_pdf(title, sections)
+    col1, col2 = st.columns(2)
+    col1.download_button(
+        "Markdownでダウンロード",
+        data=markdown.encode("utf-8"),
+        file_name=f"{base_file_name}.md",
+        mime="text/markdown",
+    )
+    col2.download_button(
+        "PDFでダウンロード",
+        data=pdf_bytes,
+        file_name=f"{base_file_name}.pdf",
+        mime="application/pdf",
+    )


### PR DESCRIPTION
## Summary
- add themed KPI highlight cards to the dashboard with target comparisons and growth metrics
- implement a guided cash flow input wizard with progress tracking, contextual tips, and validation alerts
- introduce Markdown and PDF dashboard report exports with reusable helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e76b4cf45c832391d94b62e4e53bff