### PR TITLE
Enhance simulation interactivity and strategy tooling

### DIFF
--- a/streamlit_app/analytics/simulation.py
+++ b/streamlit_app/analytics/simulation.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Iterable
+from typing import Dict, Iterable, List
 
 import numpy as np
 import pandas as pd
@@ -40,3 +40,42 @@ def required_sales(inputs: SimulationInputs) -> Dict[str, float]:
 
 def consolidate_fixed_costs(costs: Dict[str, float]) -> float:
     return float(sum(costs.values()))
+
+
+def annual_cash_flow(*, sales: float, gross_margin: float, fixed_cost: float) -> float:
+    """Return annual operating cash flow for a scenario."""
+
+    gross_profit = max(sales * gross_margin, 0.0)
+    return gross_profit - fixed_cost
+
+
+def project_cash_flows(
+    annual_cash_flow: float, growth_rate: float, periods: int
+) -> List[float]:
+    """Generate a list of future cash flows applying a constant growth rate."""
+
+    flows: List[float] = []
+    if periods <= 0:
+        return flows
+    value = float(annual_cash_flow)
+    for _ in range(periods):
+        flows.append(value)
+        value *= 1 + growth_rate
+    return flows
+
+
+def net_present_value(
+    cash_flows: Iterable[float], discount_rate: float, *, initial_investment: float = 0.0
+) -> float:
+    """Calculate the net present value for a series of future cash flows."""
+
+    npv = -float(initial_investment)
+    period = 1
+    for flow in cash_flows:
+        discount_factor = (1 + discount_rate) ** period
+        if discount_factor == 0:
+            period += 1
+            continue
+        npv += float(flow) / discount_factor
+        period += 1
+    return npv

--- a/streamlit_app/components/sidebar.py
+++ b/streamlit_app/components/sidebar.py
@@ -112,9 +112,16 @@ def render_sidebar(
     }
 
     if data_source_mode == "csv":
-        uploaded_sales = st.sidebar.file_uploader("売上CSVをアップロード", type="csv")
-        uploaded_inventory = st.sidebar.file_uploader("仕入/在庫CSVをアップロード", type="csv")
-        uploaded_fixed_costs = st.sidebar.file_uploader("固定費CSVをアップロード", type="csv")
+        file_types = ["csv", "xlsx", "xls"]
+        uploaded_sales = st.sidebar.file_uploader(
+            "売上データをアップロード", type=file_types
+        )
+        uploaded_inventory = st.sidebar.file_uploader(
+            "仕入/在庫データをアップロード", type=file_types
+        )
+        uploaded_fixed_costs = st.sidebar.file_uploader(
+            "固定費データをアップロード", type=file_types
+        )
     else:
         if providers:
             default_end = default_period[1]

--- a/streamlit_app/session_storage.py
+++ b/streamlit_app/session_storage.py
@@ -1,0 +1,48 @@
+"""Helpers to persist selected Streamlit session state keys across reruns."""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, Iterable, Mapping
+
+logger = logging.getLogger(__name__)
+
+SESSION_STATE_PATH = Path.home() / ".matsuya_app_state.json"
+
+
+def load_state() -> Dict[str, object]:
+    """Load persisted session state values from disk."""
+
+    if not SESSION_STATE_PATH.exists():
+        return {}
+    try:
+        with SESSION_STATE_PATH.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("Failed to load persisted session state")
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def save_state(values: Mapping[str, object]) -> None:
+    """Persist a subset of session state values to disk."""
+
+    try:
+        SESSION_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with SESSION_STATE_PATH.open("w", encoding="utf-8") as handle:
+            json.dump(values, handle, ensure_ascii=False, indent=2)
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception("Failed to persist session state")
+
+
+def extract_values(keys: Iterable[str], state: Mapping[str, object]) -> Dict[str, object]:
+    """Return JSON-serialisable values from ``state`` limited to ``keys``."""
+
+    data: Dict[str, object] = {}
+    for key in keys:
+        if key not in state:
+            continue
+        value = state.get(key)
+        data[key] = value
+    return data


### PR DESCRIPTION
## Summary
- add Excel upload support and persist key session state to disk to avoid reconfiguration
- expand the cash-flow simulator with real-time sliders, NPV projection, and scenario comparison utilities
- integrate strategy frameworks with interactive PESTEL, SWOT, and balanced scorecard views plus keyboard shortcuts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e76b61cc4c8323b17bda1411fc56a9