### PR TITLE
Add unified design system and advanced simulation insights

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ plotly>=5.15
 numpy>=1.23
 reportlab>=3.6
 streamlit-plotly-events>=0.0.6
+requests>=2.31

--- a/streamlit_app/analytics/__init__.py
+++ b/streamlit_app/analytics/__init__.py
@@ -1,0 +1,12 @@
+"""Analytics namespace exports."""
+
+from . import advisor, inventory, products, profitability, sales, simulation
+
+__all__ = [
+    "advisor",
+    "inventory",
+    "products",
+    "profitability",
+    "sales",
+    "simulation",
+]

--- a/streamlit_app/analytics/advisor.py
+++ b/streamlit_app/analytics/advisor.py
@@ -1,0 +1,222 @@
+"""Rule-based advisor that surfaces narrative insights for managers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+import pandas as pd
+
+
+@dataclass
+class AdvisorContext:
+    """Key metrics required to evaluate management insights."""
+
+    total_sales: float
+    operating_profit: float
+    stockout_items: int
+    cash_balance: float
+    target_profit: float
+
+
+@dataclass
+class AdvisorInsight:
+    """Structured insight returned by the advisor."""
+
+    title: str
+    description: str
+    severity: str = "info"
+    tags: Iterable[str] = ()
+
+
+def _locate_benchmark(
+    benchmark_df: Optional[pd.DataFrame], key_candidates: Iterable[str]
+) -> Optional[pd.Series]:
+    if benchmark_df is None or benchmark_df.empty:
+        return None
+    normalized = benchmark_df.copy()
+    if "metric" not in normalized.columns:
+        return None
+    normalized["metric"] = normalized["metric"].astype(str).str.lower()
+    for key in key_candidates:
+        match = normalized.loc[normalized["metric"] == key.lower()]
+        if not match.empty:
+            return match.iloc[0]
+    return None
+
+
+def generate_advice(
+    context: AdvisorContext,
+    *,
+    benchmark_df: Optional[pd.DataFrame] = None,
+    monte_carlo_probability: Optional[float] = None,
+    expected_profit: Optional[float] = None,
+    sensitivity_df: Optional[pd.DataFrame] = None,
+) -> List[AdvisorInsight]:
+    """Generate qualitative advice based on the analytical outputs."""
+
+    insights: List[AdvisorInsight] = []
+    operating_margin = (
+        context.operating_profit / context.total_sales if context.total_sales else 0.0
+    )
+
+    if monte_carlo_probability is not None:
+        if monte_carlo_probability < 0.3:
+            insights.append(
+                AdvisorInsight(
+                    title="目標利益の達成確率が低下しています",
+                    description=(
+                        f"モンテカルロ試算の結果、目標利益の達成確率は{monte_carlo_probability:.0%}です。"
+                        " コスト構造の見直しや販促強化など、追加の対策を即時検討してください。"
+                    ),
+                    severity="danger",
+                    tags=["リスク", "確率分析"],
+                )
+            )
+        elif monte_carlo_probability < 0.55:
+            insights.append(
+                AdvisorInsight(
+                    title="目標利益達成に向けた改善余地があります",
+                    description=(
+                        f"達成確率は{monte_carlo_probability:.0%}です。粗利率の底上げや固定費の圧縮を行えば"
+                        " 達成確度を高められます。"
+                    ),
+                    severity="warning",
+                    tags=["モンテカルロ", "利益"],
+                )
+            )
+        elif monte_carlo_probability > 0.75:
+            insights.append(
+                AdvisorInsight(
+                    title="利益目標の達成見込みは良好です",
+                    description=(
+                        f"達成確率が{monte_carlo_probability:.0%}まで向上しています。"
+                        " 計画通りの在庫確保と売上維持に注力しましょう。"
+                    ),
+                    severity="success",
+                    tags=["好調", "予測"],
+                )
+            )
+
+    operating_margin_benchmark = _locate_benchmark(
+        benchmark_df, ["operating_margin", "営業利益率"]
+    )
+    if operating_margin_benchmark is not None:
+        industry_margin = float(operating_margin_benchmark.get("industry_avg", 0.0))
+        if operating_margin + 1e-6 < industry_margin:
+            diff = (industry_margin - operating_margin) * 100
+            insights.append(
+                AdvisorInsight(
+                    title="営業利益率が業界平均を下回っています",
+                    description=(
+                        f"現在の営業利益率は{operating_margin:.1%}で、業界平均({industry_margin:.1%})より"
+                        f" {diff:.1f}ポイント低い水準です。粗利率向上のための値付け見直しや、固定費の最適化を検討してください。"
+                    ),
+                    severity="warning",
+                    tags=["ベンチマーク", "利益率"],
+                )
+            )
+        elif operating_margin > industry_margin:
+            insights.append(
+                AdvisorInsight(
+                    title="営業利益率は業界平均を上回っています",
+                    description=(
+                        f"営業利益率は{operating_margin:.1%}で、業界平均({industry_margin:.1%})を上回っています。"
+                        " 優位性を維持するため、在庫効率化と販促施策の継続を推奨します。"
+                    ),
+                    severity="success",
+                    tags=["ベンチマーク", "利益率"],
+                )
+            )
+
+    if context.stockout_items > 0:
+        insights.append(
+            AdvisorInsight(
+                title="欠品リスクが顕在化しています",
+                description=(
+                    f"安全在庫を下回る品目が{context.stockout_items}件あります。"
+                    " 発注サイクルの短縮や需要予測の更新を実施してください。"
+                ),
+                severity="warning",
+                tags=["在庫", "需要予測"],
+            )
+        )
+
+    if context.cash_balance < context.target_profit:
+        insights.append(
+            AdvisorInsight(
+                title="現預金残高が目標利益を下回っています",
+                description=(
+                    f"現預金残高は{context.cash_balance:,.0f}円で、目標利益{context.target_profit:,.0f}円を下回ります。"
+                    " 回収サイトの短縮や支払条件の見直しで資金繰りを改善しましょう。"
+                ),
+                severity="warning",
+                tags=["資金繰り", "キャッシュフロー"],
+            )
+        )
+
+    if expected_profit is not None and expected_profit < context.target_profit:
+        diff = context.target_profit - expected_profit
+        insights.append(
+            AdvisorInsight(
+                title="予測営業利益が目標を下回っています",
+                description=(
+                    f"シミュレーション上の平均営業利益は{expected_profit:,.0f}円で、目標利益を{diff:,.0f}円下回ります。"
+                    " 価格改定や高粗利商品の販促強化を検討してください。"
+                ),
+                severity="danger",
+                tags=["利益", "シミュレーション"],
+            )
+        )
+
+    if sensitivity_df is not None and not sensitivity_df.empty:
+        margin_df = sensitivity_df[sensitivity_df["parameter"] == "gross_margin"]
+        if not margin_df.empty:
+            upside = margin_df[margin_df["change_pct"] > 0].tail(1)
+            if not upside.empty:
+                gap = float(upside.iloc[0]["gap_to_target"])
+                margin_change = float(upside.iloc[0]["change_pct"]) * 100
+                if gap >= 0:
+                    insights.append(
+                        AdvisorInsight(
+                            title="粗利率改善で目標達成が可能です",
+                            description=(
+                                f"粗利率を{margin_change:.1f}%ポイント改善すると、目標利益を達成できる見込みです。"
+                                " 高付加価値商品の販売強化や仕入れ条件の交渉を行いましょう。"
+                            ),
+                            severity="info",
+                            tags=["感度分析", "粗利"],
+                        )
+                    )
+
+        cost_df = sensitivity_df[sensitivity_df["parameter"] == "fixed_cost"]
+        if not cost_df.empty:
+            worst = cost_df.sort_values("change_pct").head(1)
+            if not worst.empty and float(worst.iloc[0]["gap_to_target"]) < 0:
+                insights.append(
+                    AdvisorInsight(
+                        title="固定費の上振れに注意が必要です",
+                        description=(
+                            "固定費が増加すると目標利益からの乖離が拡大します。"
+                            " 契約更改前のコスト見直しや省エネ施策を検討してください。"
+                        ),
+                        severity="warning",
+                        tags=["固定費", "感度分析"],
+                    )
+                )
+
+    if not insights:
+        insights.append(
+            AdvisorInsight(
+                title="主要指標は健全に推移しています",
+                description=(
+                    "現在、重大なリスクは検出されていません。日次モニタリングを継続してください。"
+                ),
+                severity="success",
+                tags=["安定運用"],
+            )
+        )
+
+    return insights
+
+
+__all__ = ["AdvisorContext", "AdvisorInsight", "generate_advice"]

--- a/streamlit_app/analytics/simulation.py
+++ b/streamlit_app/analytics/simulation.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Iterable
+from typing import Dict, Iterable, List, Sequence
 
 import numpy as np
 import pandas as pd
@@ -16,6 +16,28 @@ class SimulationInputs:
 
 
 DEFAULT_MARGIN_RANGE = np.linspace(0.3, 0.8, num=11)
+
+
+@dataclass
+class MonteCarloConfig:
+    """Configuration options for the Monte Carlo simulation."""
+
+    iterations: int = 2000
+    demand_growth_mean: float = 0.02
+    demand_growth_std: float = 0.05
+    margin_std: float = 0.03
+    fixed_cost_std: float = 0.02
+    random_seed: int = 42
+
+
+@dataclass
+class MonteCarloResult:
+    """Container with the raw trial outputs and summary statistics."""
+
+    trials: pd.DataFrame
+    summary: pd.DataFrame
+    probability_of_target: float
+    expected_profit: float
 
 
 def breakeven_sales_curve(margins: Iterable[float], fixed_cost: float) -> pd.DataFrame:
@@ -40,3 +62,123 @@ def required_sales(inputs: SimulationInputs) -> Dict[str, float]:
 
 def consolidate_fixed_costs(costs: Dict[str, float]) -> float:
     return float(sum(costs.values()))
+
+
+def run_monte_carlo(
+    inputs: SimulationInputs,
+    *,
+    base_sales: float,
+    config: MonteCarloConfig | None = None,
+) -> MonteCarloResult:
+    """Simulate profit outcomes under probabilistic demand and cost scenarios."""
+
+    if config is None:
+        config = MonteCarloConfig()
+
+    iterations = max(int(config.iterations), 1)
+    rng = np.random.default_rng(config.random_seed)
+
+    demand_growth = rng.normal(
+        loc=config.demand_growth_mean, scale=config.demand_growth_std, size=iterations
+    )
+    simulated_sales = np.maximum(base_sales * (1 + demand_growth), 0.0)
+
+    margin_draw = rng.normal(
+        loc=inputs.gross_margin, scale=config.margin_std, size=iterations
+    )
+    simulated_margin = np.clip(margin_draw, 0.01, 0.95)
+
+    fixed_cost_draw = rng.normal(
+        loc=inputs.fixed_cost, scale=inputs.fixed_cost * config.fixed_cost_std, size=iterations
+    )
+    simulated_fixed_cost = np.maximum(fixed_cost_draw, 0.0)
+
+    gross_profit = simulated_sales * simulated_margin
+    operating_profit = gross_profit - simulated_fixed_cost
+    gap_to_target = operating_profit - inputs.target_profit
+    achieved_target = operating_profit >= inputs.target_profit
+
+    trials = pd.DataFrame(
+        {
+            "sales": simulated_sales,
+            "gross_margin": simulated_margin,
+            "fixed_cost": simulated_fixed_cost,
+            "operating_profit": operating_profit,
+            "gap_to_target": gap_to_target,
+            "achieved_target": achieved_target,
+        }
+    )
+
+    percentiles = [5, 25, 50, 75, 95]
+    summary_records: List[Dict[str, float]] = []
+    for percentile in percentiles:
+        summary_records.append(
+            {
+                "percentile": percentile,
+                "sales": float(np.percentile(simulated_sales, percentile)),
+                "operating_profit": float(np.percentile(operating_profit, percentile)),
+            }
+        )
+    summary = pd.DataFrame(summary_records)
+
+    probability = float(np.mean(achieved_target))
+    expected_profit = float(np.mean(operating_profit))
+
+    return MonteCarloResult(
+        trials=trials,
+        summary=summary,
+        probability_of_target=probability,
+        expected_profit=expected_profit,
+    )
+
+
+def sensitivity_analysis(
+    inputs: SimulationInputs,
+    *,
+    base_sales: float,
+    variation_steps: Dict[str, Sequence[float]] | None = None,
+) -> pd.DataFrame:
+    """Return a sensitivity table for margin, cost and demand variations."""
+
+    if variation_steps is None:
+        variation_steps = {
+            "gross_margin": (-0.05, -0.02, 0.0, 0.02, 0.05),
+            "fixed_cost": (-0.1, -0.05, 0.0, 0.05, 0.1),
+            "demand": (-0.1, -0.05, 0.0, 0.05, 0.1),
+        }
+
+    records: List[Dict[str, float | str]] = []
+
+    for parameter, steps in variation_steps.items():
+        for step in steps:
+            if parameter == "gross_margin":
+                margin = float(np.clip(inputs.gross_margin * (1 + step), 0.01, 0.95))
+                sales = base_sales
+                fixed_cost = inputs.fixed_cost
+            elif parameter == "fixed_cost":
+                margin = inputs.gross_margin
+                sales = base_sales
+                fixed_cost = max(inputs.fixed_cost * (1 + step), 0.0)
+            else:
+                margin = inputs.gross_margin
+                sales = max(base_sales * (1 + step), 0.0)
+                fixed_cost = inputs.fixed_cost
+
+            gross_profit = sales * margin
+            operating_profit = gross_profit - fixed_cost
+            breakeven = fixed_cost / max(margin, 1e-6)
+            records.append(
+                {
+                    "parameter": parameter,
+                    "change_pct": float(step),
+                    "sales": float(sales),
+                    "gross_margin": float(margin),
+                    "fixed_cost": float(fixed_cost),
+                    "operating_profit": float(operating_profit),
+                    "gap_to_target": float(operating_profit - inputs.target_profit),
+                    "breakeven_sales": float(breakeven),
+                }
+            )
+
+    result = pd.DataFrame(records)
+    return result.sort_values(["parameter", "change_pct"]).reset_index(drop=True)

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -20,9 +20,15 @@ if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
 from streamlit_app import data_loader, rerun as trigger_rerun, transformers
-from streamlit_app.analytics import inventory, products, profitability, sales, simulation
-from streamlit_app.components import import_dashboard, report, sidebar
-from streamlit_app.integrations import IntegrationResult, available_providers, fetch_datasets
+from streamlit_app.analytics import advisor, inventory, products, profitability, sales, simulation
+from streamlit_app.components import design_system, import_dashboard, report, sidebar
+from streamlit_app.integrations import (
+    DEFAULT_BENCHMARKS,
+    IntegrationResult,
+    available_providers,
+    fetch_benchmark_indicators,
+    fetch_datasets,
+)
 from streamlit_app.theme import inject_custom_css
 
 
@@ -3951,27 +3957,35 @@ def render_cash_tab(
     results_col, saved_col = st.columns([3, 2])
     with results_col:
         progress_display = f"{progress_ratio:.1%}" if target_sales_value > 0 else "ー"
-        summary_card_html = f"""
-        <div style="border:1px solid #dee2e6;border-radius:0.75rem;padding:1.5rem;background-color:#ffffff;margin-bottom:1rem;">
-            <div style="font-size:0.9rem;color:#6c757d;">損益分岐点売上</div>
-            <div style="font-size:2.6rem;font-weight:600;line-height:1.1;">{breakeven_sales_value:,.0f}<span style="font-size:1.2rem;"> 円</span></div>
-            <div style="margin-top:1.2rem;display:flex;flex-wrap:wrap;gap:1.5rem;">
-                <div>
-                    <div style="font-size:0.85rem;color:#6c757d;">目標利益達成に必要な売上</div>
-                    <div style="font-size:1.2rem;font-weight:500;">{target_sales_value:,.0f} 円</div>
-                </div>
-                <div>
-                    <div style="font-size:0.85rem;color:#6c757d;">現状売上</div>
-                    <div style="font-size:1.2rem;font-weight:500;">{current_sales_value:,.0f} 円</div>
-                </div>
-                <div>
-                    <div style="font-size:0.85rem;color:#6c757d;">目標達成率</div>
-                    <div style="font-size:1.2rem;font-weight:500;">{progress_display}</div>
-                </div>
-            </div>
-        </div>
-        """
-        st.markdown(summary_card_html, unsafe_allow_html=True)
+        attainment_gap = current_sales_value - target_sales_value
+        chip_label = None
+        chip_severity = "info"
+        if target_sales_value > 0:
+            chip_label = f"達成率 {progress_display}"
+            chip_severity = "success" if reached_target else "warning"
+        design_system.render_section_title(
+            "シミュレーション要約",
+            chip=chip_label,
+            severity=chip_severity,
+        )
+        summary_metrics = [
+            design_system.Metric(
+                label="損益分岐点売上",
+                value=f"{breakeven_sales_value:,.0f} 円",
+                caption="固定費÷粗利率で算出",
+            ),
+            design_system.Metric(
+                label="目標利益達成に必要な売上",
+                value=f"{target_sales_value:,.0f} 円",
+                caption="目標利益+固定費に基づく",
+            ),
+            design_system.Metric(
+                label="現状売上",
+                value=f"{current_sales_value:,.0f} 円",
+                caption=f"目標差 {attainment_gap:+,.0f} 円",
+            ),
+        ]
+        design_system.render_metric_grid(summary_metrics)
 
         success_color = colors["success"]
         error_color = colors["error"]
@@ -4075,6 +4089,317 @@ def render_cash_tab(
             key="save_simulation_scenario",
             on_click=_save_scenario,
         )
+
+    monte_carlo_config = simulation.MonteCarloConfig(
+        iterations=3000,
+        demand_growth_mean=0.01,
+        demand_growth_std=0.04,
+        margin_std=0.025,
+        fixed_cost_std=0.02,
+    )
+    monte_carlo_result = simulation.run_monte_carlo(
+        inputs,
+        base_sales=max(current_sales_value, 1.0),
+        config=monte_carlo_config,
+    )
+    sensitivity_df = simulation.sensitivity_analysis(
+        inputs,
+        base_sales=max(current_sales_value, 1.0),
+    )
+
+    probability = monte_carlo_result.probability_of_target
+    probability_chip = f"達成確率 {probability:.0%}"
+    probability_severity = "warning"
+    if probability >= 0.7:
+        probability_severity = "success"
+    elif probability < 0.4:
+        probability_severity = "danger"
+
+    st.divider()
+    design_system.render_section_title(
+        "リスク分析",
+        chip=probability_chip,
+        severity=probability_severity,
+    )
+    risk_cols = st.columns([3, 2], gap="large")
+    probability_colors = {
+        "目標達成": colors["success"],
+        "未達": colors["error"],
+    }
+    with risk_cols[0]:
+        trial_display = monte_carlo_result.trials.copy()
+        trial_display["達成状況"] = trial_display["achieved_target"].map(
+            {True: "目標達成", False: "未達"}
+        )
+        dist_chart = px.histogram(
+            trial_display,
+            x="operating_profit",
+            nbins=40,
+            color="達成状況",
+            color_discrete_map=probability_colors,
+            labels={
+                "operating_profit": "営業利益（円）",
+                "達成状況": "目標達成",
+            },
+        )
+        dist_chart.add_vline(
+            x=inputs.target_profit,
+            line_dash="dash",
+            line_color=colors["accent"],
+            annotation_text="目標利益",
+            annotation_position="top left",
+        )
+        dist_chart.update_layout(
+            bargap=0.02,
+            showlegend=True,
+            legend=dict(title="目標達成"),
+        )
+        st.plotly_chart(dist_chart, use_container_width=True)
+
+    with risk_cols[1]:
+        summary_lookup = monte_carlo_result.summary.set_index("percentile")
+        percentile_75 = float(summary_lookup.loc[75, "operating_profit"])
+        percentile_25 = float(summary_lookup.loc[25, "operating_profit"])
+        highlight_metrics = [
+            design_system.Metric(
+                label="期待営業利益",
+                value=f"{monte_carlo_result.expected_profit:,.0f} 円",
+                caption="シミュレーション平均",
+            ),
+            design_system.Metric(
+                label="P75 営業利益",
+                value=f"{percentile_75:,.0f} 円",
+                caption="上振れシナリオ",
+            ),
+            design_system.Metric(
+                label="P25 営業利益",
+                value=f"{percentile_25:,.0f} 円",
+                caption="下振れシナリオ",
+            ),
+        ]
+        design_system.render_metric_grid(highlight_metrics)
+        percentile_display = monte_carlo_result.summary.assign(
+            percentile=lambda df: df["percentile"].astype(int).astype(str) + "%"
+        )
+        percentile_display = percentile_display.rename(
+            columns={
+                "percentile": "パーセンタイル",
+                "sales": "売上（円）",
+                "operating_profit": "営業利益（円）",
+            }
+        )
+        st.dataframe(
+            percentile_display.style.format(
+                {"売上（円）": "{:,.0f}", "営業利益（円）": "{:,.0f}"}
+            ),
+            use_container_width=True,
+            hide_index=True,
+        )
+
+    st.markdown("##### 感度分析")
+    sensitivity_chart = px.line(
+        sensitivity_df,
+        x="change_pct",
+        y="operating_profit",
+        color="parameter",
+        markers=True,
+        labels={
+            "change_pct": "変化率",
+            "operating_profit": "営業利益（円）",
+            "parameter": "指標",
+        },
+    )
+    sensitivity_chart.update_xaxes(tickformat=".0%")
+    sensitivity_chart.update_layout(legend=dict(title="指標"))
+    sensitivity_chart.add_hline(
+        y=inputs.target_profit,
+        line_dash="dash",
+        line_color=colors["accent"],
+        annotation_text="目標利益",
+        annotation_position="top left",
+    )
+    st.plotly_chart(sensitivity_chart, use_container_width=True)
+
+    parameter_labels = {
+        "gross_margin": "粗利率",
+        "fixed_cost": "固定費",
+        "demand": "需要",
+    }
+    sensitivity_records = []
+    for parameter, group in sensitivity_df.groupby("parameter"):
+        positives = group.loc[group["gap_to_target"] >= 0, "change_pct"]
+        change_needed = float(positives.min()) if not positives.empty else None
+        sensitivity_records.append(
+            {
+                "指標": parameter_labels.get(parameter, parameter),
+                "最小営業利益": float(group["operating_profit"].min()),
+                "最大営業利益": float(group["operating_profit"].max()),
+                "目標達成に必要な変化率": change_needed,
+            }
+        )
+    sensitivity_summary = pd.DataFrame(sensitivity_records)
+    if not sensitivity_summary.empty:
+        st.dataframe(
+            sensitivity_summary.style.format(
+                {
+                    "最小営業利益": "{:,.0f}",
+                    "最大営業利益": "{:,.0f}",
+                    "目標達成に必要な変化率": "{:.1%}",
+                }
+            ),
+            use_container_width=True,
+            hide_index=True,
+        )
+
+    if "benchmark_params" not in st.session_state:
+        st.session_state["benchmark_params"] = {
+            "industry": "外食",
+            "region": "全国",
+            "api_url": "",
+            "api_key": "",
+        }
+
+    benchmark_params = st.session_state["benchmark_params"]
+    industry_options = ["外食", "小売", "飲食チェーン"]
+    region_options = ["全国", "関東", "関西", "北海道・東北"]
+    with st.expander("業界ベンチマークを取得", expanded=False):
+        with st.form("benchmark_fetch_form"):
+            industry = st.selectbox(
+                "業界カテゴリ",
+                industry_options,
+                index=industry_options.index(benchmark_params.get("industry", industry_options[0]))
+                if benchmark_params.get("industry") in industry_options
+                else 0,
+            )
+            region = st.selectbox(
+                "地域",
+                region_options,
+                index=region_options.index(benchmark_params.get("region", region_options[0]))
+                if benchmark_params.get("region") in region_options
+                else 0,
+            )
+            api_url = st.text_input(
+                "APIエンドポイント (未入力の場合はサンプルデータ)",
+                value=benchmark_params.get("api_url", ""),
+            )
+            api_key = st.text_input(
+                "APIキー (任意)",
+                value=benchmark_params.get("api_key", ""),
+                type="password",
+            )
+            submitted_benchmark = st.form_submit_button("ベンチマークを取得", type="primary")
+        if submitted_benchmark:
+            st.session_state["benchmark_params"].update(
+                {"industry": industry, "region": region, "api_url": api_url, "api_key": api_key}
+            )
+            selected_metrics = ["operating_margin", "sales_growth", "inventory_turnover"]
+            benchmark_df = fetch_benchmark_indicators(
+                api_url=api_url.strip(),
+                industry=industry,
+                region=None if region == "全国" else region,
+                metrics=selected_metrics,
+                api_key=api_key or None,
+            )
+            st.session_state["benchmark_df"] = benchmark_df
+            st.success("ベンチマークデータを更新しました。")
+
+    benchmark_df = st.session_state.get("benchmark_df", DEFAULT_BENCHMARKS.copy())
+    previous_sales_value = (
+        float(comparison_sales["sales_amount"].sum()) if not comparison_sales.empty else None
+    )
+    sales_growth_rate = _compute_growth(current_sales_value, previous_sales_value)
+    overview_for_bench = inventory.inventory_overview(
+        sales_df,
+        inventory_df,
+        start_date=filters.start_date,
+        end_date=filters.end_date,
+    )
+    turnover_ratio = (
+        float(overview_for_bench.get("turnover_ratio", pd.Series(dtype=float)).mean())
+        if not overview_for_bench.empty and "turnover_ratio" in overview_for_bench
+        else None
+    )
+
+    operating_profit_total = float(pnl_df.get("operating_profit", pd.Series(dtype=float)).sum())
+    operating_margin_value = (
+        operating_profit_total / current_sales_value if current_sales_value else 0.0
+    )
+
+    company_metrics = {
+        "operating_margin": operating_margin_value,
+        "sales_growth": sales_growth_rate,
+        "inventory_turnover": turnover_ratio,
+    }
+    metric_labels = {
+        "operating_margin": "営業利益率",
+        "sales_growth": "売上成長率",
+        "inventory_turnover": "在庫回転率",
+    }
+
+    if not benchmark_df.empty:
+        display_df = benchmark_df.copy()
+        display_df["指標"] = display_df["metric"].map(metric_labels).fillna(display_df["metric"])
+        display_df["自社実績"] = display_df["metric"].map(company_metrics)
+        display_df["業界平均との差"] = display_df["自社実績"] - display_df["industry_avg"]
+
+        def _format_indicator(value: float | None, unit: str) -> str:
+            if value is None or (isinstance(value, float) and pd.isna(value)):
+                return "-"
+            if unit == "ratio":
+                return f"{value * 100:.1f}%"
+            return f"{value:,.2f}"
+
+        display_df["業界平均"] = [
+            _format_indicator(val, unit)
+            for val, unit in zip(display_df["industry_avg"], display_df["unit"])
+        ]
+        display_df["上位25%水準"] = [
+            _format_indicator(val, unit)
+            for val, unit in zip(display_df["top_quartile"], display_df["unit"])
+        ]
+        display_df["自社実績"] = [
+            _format_indicator(val, unit)
+            for val, unit in zip(display_df["自社実績"], display_df["unit"])
+        ]
+        display_df["業界平均との差"] = [
+            _format_indicator(val, unit)
+            for val, unit in zip(display_df["業界平均との差"], display_df["unit"])
+        ]
+        display_table = display_df[
+            ["指標", "業界平均", "上位25%水準", "自社実績", "業界平均との差"]
+        ]
+        design_system.render_section_title("ベンチマーク比較", chip="外部データ", severity="info")
+        design_system.render_surface(display_table.to_html(index=False, escape=False))
+
+    stockout_items = 0
+    if not overview_for_bench.empty and "stock_status" in overview_for_bench:
+        stockout_items = int((overview_for_bench["stock_status"] == "在庫切れ").sum())
+
+    advice_context = advisor.AdvisorContext(
+        total_sales=current_sales_value,
+        operating_profit=operating_profit_total,
+        stockout_items=stockout_items,
+        cash_balance=cash_current.get("balance", 0.0),
+        target_profit=target_profit,
+    )
+    advice_items = advisor.generate_advice(
+        advice_context,
+        benchmark_df=benchmark_df,
+        monte_carlo_probability=probability,
+        expected_profit=monte_carlo_result.expected_profit,
+        sensitivity_df=sensitivity_df,
+    )
+    design_system.render_section_title("AIによる経営アドバイス", chip="ベータ版", severity="info")
+    design_insights = [
+        design_system.Insight(
+            title=item.title,
+            description=item.description,
+            severity=item.severity,
+            tags=list(item.tags),
+        )
+        for item in advice_items
+    ]
+    design_system.render_insights(design_insights)
 
     if "saved_scenarios" not in st.session_state:
         st.session_state["saved_scenarios"] = []

--- a/streamlit_app/components/__init__.py
+++ b/streamlit_app/components/__init__.py
@@ -1,0 +1,10 @@
+"""Component namespace exports for convenience."""
+
+from . import design_system, import_dashboard, report, sidebar
+
+__all__ = [
+    "design_system",
+    "import_dashboard",
+    "report",
+    "sidebar",
+]

--- a/streamlit_app/components/design_system.py
+++ b/streamlit_app/components/design_system.py
@@ -1,0 +1,135 @@
+"""Reusable UI helpers that embrace the shared design system."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Sequence
+
+import streamlit as st
+
+from streamlit_app.theme import get_design_tokens
+
+
+@dataclass
+class Metric:
+    """Representation of a metric cell rendered inside a grid."""
+
+    label: str
+    value: str
+    caption: Optional[str] = None
+
+
+@dataclass
+class Insight:
+    """Structure representing an AI generated or rule based suggestion."""
+
+    title: str
+    description: str
+    severity: str = "info"
+    tags: Sequence[str] = ()
+
+
+SEVERITY_TO_CHIP_CLASS = {
+    "success": "success",
+    "info": "info",
+    "warning": "warning",
+    "danger": "danger",
+}
+
+
+def render_surface(content: str, *, elevated: bool = False, muted: bool = False) -> None:
+    """Render HTML content inside a styled surface container."""
+
+    classes: List[str] = ["ds-surface"]
+    if elevated:
+        classes.append("elevated")
+    if muted:
+        classes.append("muted")
+    st.markdown(
+        f"""
+        <div class="{' '.join(classes)}">
+            {content}
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_metric_grid(metrics: Iterable[Metric]) -> None:
+    """Render a responsive grid of metrics following the design system."""
+
+    metric_list = list(metrics)
+    if not metric_list:
+        return
+    grid_items = []
+    for metric in metric_list:
+        caption_html = (
+            f"<div class='caption'>{metric.caption}</div>" if metric.caption else ""
+        )
+        grid_items.append(
+            f"""
+            <div class="ds-metric">
+                <div class="label">{metric.label}</div>
+                <div class="value">{metric.value}</div>
+                {caption_html}
+            </div>
+            """
+        )
+    grid_html = "".join(grid_items)
+    render_surface(f"<div class='ds-metric-grid'>{grid_html}</div>")
+
+
+def render_section_title(title: str, *, chip: Optional[str] = None, severity: str = "info") -> None:
+    """Render a heading styled using the design tokens."""
+
+    tokens = get_design_tokens()
+    chip_html = ""
+    if chip:
+        chip_class = SEVERITY_TO_CHIP_CLASS.get(severity, "info")
+        chip_html = (
+            f"<span class='ds-chip {chip_class}'>{chip}</span>"
+        )
+    st.markdown(
+        f"""
+        <div class="ds-section-title" style="display:flex;align-items:center;gap:{tokens['spacingUnit']};">
+            <span>{title}</span>
+            {chip_html}
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_insights(insights: Iterable[Insight]) -> None:
+    """Render a collection of insights with severity chips and metadata."""
+
+    items = list(insights)
+    if not items:
+        st.info("現在表示できるアドバイスはありません。")
+        return
+    insight_html = []
+    for insight in items:
+        chip_class = SEVERITY_TO_CHIP_CLASS.get(insight.severity, "info")
+        tags_html = "".join(
+            f"<span class='ds-chip info'>{tag}</span>" for tag in insight.tags
+        )
+        insight_html.append(
+            f"""
+            <div class="ds-insight">
+                <div class="ds-chip {chip_class}" style="width:fit-content;">{insight.severity.upper()}</div>
+                <strong>{insight.title}</strong>
+                <div>{insight.description}</div>
+                <div class="meta">{tags_html}</div>
+            </div>
+            """
+        )
+    render_surface("<div class='ds-insight-list'>" + "".join(insight_html) + "</div>")
+
+
+__all__ = [
+    "Metric",
+    "Insight",
+    "render_surface",
+    "render_metric_grid",
+    "render_section_title",
+    "render_insights",
+]

--- a/streamlit_app/integrations/__init__.py
+++ b/streamlit_app/integrations/__init__.py
@@ -1,8 +1,12 @@
-"""Integration helpers for external POS and accounting systems."""
+"""Integration helpers for external POS, accounting systems, and benchmarks."""
+
+from .benchmarks import DEFAULT_BENCHMARKS, fetch_benchmark_indicators
 from .manager import IntegrationResult, available_providers, fetch_datasets
 
 __all__ = [
+    "DEFAULT_BENCHMARKS",
     "IntegrationResult",
     "available_providers",
+    "fetch_benchmark_indicators",
     "fetch_datasets",
 ]

--- a/streamlit_app/integrations/benchmarks.py
+++ b/streamlit_app/integrations/benchmarks.py
@@ -1,0 +1,82 @@
+"""Helper functions for retrieving external benchmark datasets."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, Optional
+
+import pandas as pd
+
+try:  # pragma: no cover - optional dependency
+    import requests
+except Exception:  # pragma: no cover - graceful degradation
+    requests = None  # type: ignore[assignment]
+
+
+DEFAULT_BENCHMARKS = pd.DataFrame(
+    [
+        {
+            "metric": "operating_margin",
+            "industry_avg": 0.085,
+            "top_quartile": 0.12,
+            "unit": "ratio",
+        },
+        {
+            "metric": "sales_growth",
+            "industry_avg": 0.031,
+            "top_quartile": 0.056,
+            "unit": "ratio",
+        },
+        {
+            "metric": "inventory_turnover",
+            "industry_avg": 10.5,
+            "top_quartile": 14.2,
+            "unit": "times",
+        },
+    ]
+)
+
+
+def fetch_benchmark_indicators(
+    *,
+    api_url: str,
+    industry: str,
+    region: Optional[str] = None,
+    metrics: Optional[Iterable[str]] = None,
+    api_key: Optional[str] = None,
+    timeout: float = 5.0,
+) -> pd.DataFrame:
+    """Fetch benchmark metrics from an external API with sensible fallbacks."""
+
+    params: Dict[str, object] = {"industry": industry}
+    if region:
+        params["region"] = region
+    if metrics:
+        params["metrics"] = ",".join(metrics)
+
+    headers: Dict[str, str] = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    if not api_url:
+        return DEFAULT_BENCHMARKS.copy()
+
+    if requests is None:
+        return DEFAULT_BENCHMARKS.copy()
+
+    try:
+        response = requests.get(api_url, params=params, headers=headers, timeout=timeout)
+        response.raise_for_status()
+        payload = response.json()
+    except Exception:
+        return DEFAULT_BENCHMARKS.copy()
+
+    data = payload.get("benchmarks") if isinstance(payload, dict) else None
+    if not data:
+        return DEFAULT_BENCHMARKS.copy()
+
+    df = pd.DataFrame(data)
+    if "metric" not in df.columns:
+        return DEFAULT_BENCHMARKS.copy()
+    return df
+
+
+__all__ = ["DEFAULT_BENCHMARKS", "fetch_benchmark_indicators"]

--- a/streamlit_app/theme.py
+++ b/streamlit_app/theme.py
@@ -12,17 +12,32 @@ DESIGN_TOKENS = {
     "accentColor": "#1E88E5",
     "backgroundColor": "#F7F8FA",
     "cardBackground": "#FFFFFF",
+    "surfaceMuted": "#EEF2F6",
     "successColor": "#3FB27E",
     "warningColor": "#E9A13B",
     "errorColor": "#E55353",
+    "infoColor": "#2563EB",
     "fontFamilyBase": "'Inter', 'Source Sans 3', sans-serif",
     "fontFamilyNumeric": "'Roboto Mono', monospace",
     "heading1Size": "28px",
     "heading2Size": "22px",
+    "heading3Size": "18px",
     "bodySize": "16px",
     "smallTextSize": "14px",
+    "microTextSize": "12px",
     "spacingUnit": "8px",
+    "radiusSm": "6px",
+    "radiusMd": "12px",
+    "radiusLg": "18px",
+    "shadowSoft": "0 2px 6px rgba(15, 23, 42, 0.08)",
+    "shadowLifted": "0 12px 30px rgba(15, 23, 42, 0.16)",
 }
+
+
+def get_design_tokens() -> Dict[str, str]:
+    """Return a copy of the global design token dictionary."""
+
+    return dict(DESIGN_TOKENS)
 
 
 def build_custom_css() -> str:
@@ -37,16 +52,25 @@ def build_custom_css() -> str:
             --color-accent: {DESIGN_TOKENS['accentColor']};
             --color-background: {DESIGN_TOKENS['backgroundColor']};
             --color-surface: {DESIGN_TOKENS['cardBackground']};
+            --color-surface-muted: {DESIGN_TOKENS['surfaceMuted']};
             --color-success: {DESIGN_TOKENS['successColor']};
             --color-warning: {DESIGN_TOKENS['warningColor']};
             --color-error: {DESIGN_TOKENS['errorColor']};
+            --color-info: {DESIGN_TOKENS['infoColor']};
             --font-base: {DESIGN_TOKENS['fontFamilyBase']};
             --font-numeric: {DESIGN_TOKENS['fontFamilyNumeric']};
             --heading-1: {DESIGN_TOKENS['heading1Size']};
             --heading-2: {DESIGN_TOKENS['heading2Size']};
+            --heading-3: {DESIGN_TOKENS['heading3Size']};
             --text-body: {DESIGN_TOKENS['bodySize']};
             --text-small: {DESIGN_TOKENS['smallTextSize']};
+            --text-micro: {DESIGN_TOKENS['microTextSize']};
             --spacing-unit: {DESIGN_TOKENS['spacingUnit']};
+            --radius-sm: {DESIGN_TOKENS['radiusSm']};
+            --radius-md: {DESIGN_TOKENS['radiusMd']};
+            --radius-lg: {DESIGN_TOKENS['radiusLg']};
+            --shadow-soft: {DESIGN_TOKENS['shadowSoft']};
+            --shadow-lifted: {DESIGN_TOKENS['shadowLifted']};
         }}
 
         html, body, .stApp {{
@@ -183,6 +207,120 @@ def build_custom_css() -> str:
             background-color: var(--color-primary);
             color: #FFFFFF;
         }}
+
+        .ds-surface {{
+            background-color: var(--color-surface);
+            border-radius: var(--radius-md);
+            box-shadow: var(--shadow-soft);
+            padding: calc(var(--spacing-unit) * 2);
+            border: 1px solid rgba(11, 31, 59, 0.05);
+        }}
+
+        .ds-surface.elevated {{
+            box-shadow: var(--shadow-lifted);
+        }}
+
+        .ds-surface.muted {{
+            background-color: var(--color-surface-muted);
+        }}
+
+        .ds-section-title {{
+            font-size: var(--heading-3);
+            font-weight: 600;
+            color: var(--color-primary);
+            margin-bottom: calc(var(--spacing-unit) * 1.5);
+        }}
+
+        .ds-metric-grid {{
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: calc(var(--spacing-unit) * 1.5);
+        }}
+
+        .ds-metric {{
+            display: flex;
+            flex-direction: column;
+            gap: calc(var(--spacing-unit) * 0.5);
+        }}
+
+        .ds-metric .label {{
+            font-size: var(--text-small);
+            color: var(--color-secondary);
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+        }}
+
+        .ds-metric .value {{
+            font-size: 1.6rem;
+            font-weight: 600;
+            color: var(--color-primary);
+        }}
+
+        .ds-metric .caption {{
+            font-size: var(--text-small);
+            color: rgba(11, 31, 59, 0.7);
+        }}
+
+        .ds-chip {{
+            display: inline-flex;
+            align-items: center;
+            gap: calc(var(--spacing-unit) * 0.5);
+            padding: calc(var(--spacing-unit) * 0.5) calc(var(--spacing-unit) * 0.75);
+            border-radius: 999px;
+            font-size: var(--text-small);
+            font-weight: 500;
+            background-color: var(--color-surface-muted);
+            color: var(--color-primary);
+        }}
+
+        .ds-chip.success {{
+            background-color: rgba(63, 178, 126, 0.16);
+            color: var(--color-success);
+        }}
+
+        .ds-chip.warning {{
+            background-color: rgba(233, 161, 59, 0.18);
+            color: var(--color-warning);
+        }}
+
+        .ds-chip.danger {{
+            background-color: rgba(229, 83, 83, 0.18);
+            color: var(--color-error);
+        }}
+
+        .ds-chip.info {{
+            background-color: rgba(30, 136, 229, 0.14);
+            color: var(--color-info);
+        }}
+
+        .ds-insight-list {{
+            display: flex;
+            flex-direction: column;
+            gap: calc(var(--spacing-unit) * 1.5);
+        }}
+
+        .ds-insight {{
+            display: flex;
+            flex-direction: column;
+            gap: calc(var(--spacing-unit) * 0.6);
+            padding: calc(var(--spacing-unit) * 1.5);
+            border-radius: var(--radius-md);
+            border: 1px solid rgba(11, 31, 59, 0.08);
+            background-color: var(--color-surface);
+        }}
+
+        .ds-insight strong {{
+            font-size: 1rem;
+            color: var(--color-primary);
+        }}
+
+        .ds-insight .meta {{
+            display: flex;
+            gap: calc(var(--spacing-unit));
+            flex-wrap: wrap;
+            font-size: var(--text-small);
+            color: var(--color-secondary);
+        }}
         </style>
         """
     ).strip()
@@ -198,4 +336,9 @@ def inject_custom_css() -> None:
     st.session_state["_theme_css_injected"] = True
 
 
-__all__ = ["DESIGN_TOKENS", "build_custom_css", "inject_custom_css"]
+__all__ = [
+    "DESIGN_TOKENS",
+    "get_design_tokens",
+    "build_custom_css",
+    "inject_custom_css",
+]


### PR DESCRIPTION
## Summary
- establish reusable design system helpers and extend theme tokens for consistent UI styling
- add Monte Carlo risk modelling, sensitivity analysis, and benchmark API integration to the cash simulation tab
- surface AI-driven management advice based on simulation outcomes and external benchmarks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e76ba06f648323890ebc780724e551