### PR TITLE
Fix benchmark fallback when API omits fields

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -4303,7 +4303,14 @@ def render_cash_tab(
             st.session_state["benchmark_df"] = benchmark_df
             st.success("ベンチマークデータを更新しました。")
 
-    benchmark_df = st.session_state.get("benchmark_df", DEFAULT_BENCHMARKS.copy())
+    benchmark_df = st.session_state.get("benchmark_df")
+    required_benchmark_columns = {"metric", "industry_avg", "top_quartile", "unit"}
+    if not isinstance(benchmark_df, pd.DataFrame) or benchmark_df.empty:
+        benchmark_df = DEFAULT_BENCHMARKS.copy()
+    elif not required_benchmark_columns.issubset(benchmark_df.columns):
+        benchmark_df = DEFAULT_BENCHMARKS.copy()
+    else:
+        benchmark_df = benchmark_df.copy()
     previous_sales_value = (
         float(comparison_sales["sales_amount"].sum()) if not comparison_sales.empty else None
     )

--- a/streamlit_app/integrations/benchmarks.py
+++ b/streamlit_app/integrations/benchmarks.py
@@ -76,6 +76,9 @@ def fetch_benchmark_indicators(
     df = pd.DataFrame(data)
     if "metric" not in df.columns:
         return DEFAULT_BENCHMARKS.copy()
+    required_columns = {"industry_avg", "top_quartile", "unit"}
+    if not required_columns.issubset(df.columns):
+        return DEFAULT_BENCHMARKS.copy()
     return df
 
 


### PR DESCRIPTION
## Summary
- default to built-in benchmark metrics when API responses miss required fields
- ensure cached benchmark data is validated before rendering the comparison table

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e77356f6788323877c8ed91c4a894c