### PR TITLE
Add automated data sync, forecasting, and multi-axis analytics

### DIFF
--- a/streamlit_app/analytics/__init__.py
+++ b/streamlit_app/analytics/__init__.py
@@ -1,9 +1,11 @@
 """Analytics namespace exports."""
 
-from . import advisor, inventory, products, profitability, sales, simulation
+from . import alerts, advisor, forecasting, inventory, products, profitability, sales, simulation
 
 __all__ = [
+    "alerts",
     "advisor",
+    "forecasting",
     "inventory",
     "products",
     "profitability",

--- a/streamlit_app/analytics/alerts.py
+++ b/streamlit_app/analytics/alerts.py
@@ -1,0 +1,199 @@
+"""Rule-based decision support alerts for inventory and cash management."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+import pandas as pd
+
+
+@dataclass
+class DecisionAlert:
+    """Represents an actionable alert presented to the dashboard user."""
+
+    title: str
+    message: str
+    severity: str
+    recommendations: List[str]
+    category: str
+
+
+def _format_currency(value: float) -> str:
+    return f"{value:,.0f}円"
+
+
+def inventory_alerts(overview: pd.DataFrame) -> List[DecisionAlert]:
+    if overview.empty:
+        return []
+
+    alerts: List[DecisionAlert] = []
+    stockout_df = overview.loc[overview["stock_status"].isin(["在庫切れ", "在庫少"])]
+    if not stockout_df.empty:
+        items = stockout_df[["store", "product", "estimated_stock", "safety_lower"]]
+        lines = []
+        for _, row in items.head(10).iterrows():
+            store = row.get("store") or "-"
+            product = row.get("product") or "-"
+            estimated = float(row.get("estimated_stock", 0))
+            threshold = float(row.get("safety_lower", 0))
+            lines.append(
+                f"{store} - {product}: 在庫 {estimated:.0f} / 目標 {threshold:.0f}"
+            )
+        alerts.append(
+            DecisionAlert(
+                title="安全在庫を下回る品目があります",
+                message=(
+                    f"{len(stockout_df)}品目が安全在庫を下回っています。"
+                    " 補充発注を優先し、需要予測の見直しを実施してください。"
+                ),
+                severity="warning",
+                recommendations=lines,
+                category="inventory",
+            )
+        )
+
+    overstock_df = overview.loc[overview["stock_status"] == "在庫過多"]
+    if not overstock_df.empty:
+        lines = []
+        for _, row in overstock_df.head(10).iterrows():
+            store = row.get("store") or "-"
+            product = row.get("product") or "-"
+            coverage = row.get("coverage_days")
+            if pd.isna(coverage):
+                continue
+            lines.append(f"{store} - {product}: 在庫日数 {coverage:.1f}日")
+        alerts.append(
+            DecisionAlert(
+                title="過剰在庫が検出されました",
+                message=(
+                    f"{len(overstock_df)}品目が安全在庫上限を超過しています。"
+                    " 仕入数量の調整や販促による消化を検討してください。"
+                ),
+                severity="info",
+                recommendations=lines,
+                category="inventory",
+            )
+        )
+    return alerts
+
+
+def cash_flow_alerts(
+    forecast_df: pd.DataFrame,
+    *,
+    target_balance: Optional[float] = None,
+) -> List[DecisionAlert]:
+    if forecast_df.empty:
+        return []
+
+    alerts: List[DecisionAlert] = []
+    negative = forecast_df.loc[forecast_df["balance"] < 0]
+    if not negative.empty:
+        first = negative.iloc[0]
+        alerts.append(
+            DecisionAlert(
+                title="資金ショートのリスクがあります",
+                message=(
+                    f"{first['period_label']}に資金残高がマイナス({_format_currency(first['balance'])})"
+                    " となる見込みです。入金前倒しや短期借入を検討してください。"
+                ),
+                severity="danger",
+                recommendations=[
+                    "販管費の支出を見直しキャッシュアウトを抑制",
+                    "入金サイト短縮やファクタリングの検討",
+                    "不足額に応じた短期借入や資金移動の準備",
+                ],
+                category="cash",
+            )
+        )
+
+    if target_balance is not None:
+        below_target = forecast_df.loc[forecast_df["balance"] < target_balance]
+        if not below_target.empty:
+            upcoming = below_target.iloc[0]
+            alerts.append(
+                DecisionAlert(
+                    title="キャッシュ比率が目標を下回る見込みです",
+                    message=(
+                        f"{upcoming['period_label']}の残高は{_format_currency(upcoming['balance'])}で"
+                        f" 目標 {_format_currency(target_balance)} を下回ります。"
+                    ),
+                    severity="warning",
+                    recommendations=[
+                        "利益率の高い商品の拡販で粗利を底上げ",
+                        "在庫回転を改善し現金化を加速",
+                        "不要資産の売却や返済スケジュールの再交渉",
+                    ],
+                    category="cash",
+                )
+            )
+    return alerts
+
+
+def cvp_alerts(
+    sales_df: pd.DataFrame,
+    fixed_cost_df: pd.DataFrame,
+) -> List[DecisionAlert]:
+    if sales_df.empty or fixed_cost_df.empty:
+        return []
+
+    total_sales = float(sales_df["sales_amount"].sum())
+    total_gross_profit = float(sales_df["gross_profit"].sum())
+    contribution_margin_rate = total_gross_profit / total_sales if total_sales else 0.0
+    fixed_cost_columns = [
+        column
+        for column in ["rent", "payroll", "utilities", "marketing", "other_fixed"]
+        if column in fixed_cost_df.columns
+    ]
+    fixed_cost = float(fixed_cost_df[fixed_cost_columns].sum().sum())
+    if contribution_margin_rate <= 0:
+        break_even = float("inf")
+    else:
+        break_even = fixed_cost / contribution_margin_rate
+
+    alerts: List[DecisionAlert] = []
+    if total_sales < break_even and break_even != float("inf"):
+        gap = break_even - total_sales
+        alerts.append(
+            DecisionAlert(
+                title="損益分岐点を下回っています",
+                message=(
+                    f"現在の売上 { _format_currency(total_sales) } は"
+                    f" 損益分岐点 {_format_currency(break_even)} を { _format_currency(gap) } 下回ります。"
+                ),
+                severity="danger",
+                recommendations=[
+                    "高粗利商品の販売強化による貢献利益率の改善",
+                    "固定費の見直し・削減案の検討",
+                    "チャネル別の利益構造を分析し不採算を縮小",
+                ],
+                category="profitability",
+            )
+        )
+    return alerts
+
+
+def collect_alerts(
+    inventory_df: Optional[pd.DataFrame] = None,
+    cash_forecast_df: Optional[pd.DataFrame] = None,
+    *,
+    sales_df: Optional[pd.DataFrame] = None,
+    fixed_cost_df: Optional[pd.DataFrame] = None,
+    cash_target: Optional[float] = None,
+) -> List[DecisionAlert]:
+    alerts: List[DecisionAlert] = []
+    if inventory_df is not None:
+        alerts.extend(inventory_alerts(inventory_df))
+    if cash_forecast_df is not None:
+        alerts.extend(cash_flow_alerts(cash_forecast_df, target_balance=cash_target))
+    if sales_df is not None and fixed_cost_df is not None:
+        alerts.extend(cvp_alerts(sales_df, fixed_cost_df))
+    return alerts
+
+
+__all__ = [
+    "DecisionAlert",
+    "inventory_alerts",
+    "cash_flow_alerts",
+    "cvp_alerts",
+    "collect_alerts",
+]

--- a/streamlit_app/analytics/forecasting.py
+++ b/streamlit_app/analytics/forecasting.py
@@ -1,0 +1,234 @@
+"""Time-series forecasting helpers for sales and cash-flow analysis."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+try:  # pragma: no cover - optional dependency
+    from prophet import Prophet
+except Exception:  # pragma: no cover - dependency guard
+    Prophet = None
+
+try:  # pragma: no cover - optional dependency
+    from statsmodels.tsa.arima.model import ARIMA
+except Exception:  # pragma: no cover - dependency guard
+    ARIMA = None
+
+
+FREQUENCY_MAP = {
+    "daily": "D",
+    "weekly": "W-MON",
+    "monthly": "MS",
+    "yearly": "YS",
+}
+
+
+@dataclass
+class ForecastResult:
+    """Container describing the outcome of a forecasting run."""
+
+    history: pd.DataFrame
+    forecast: pd.DataFrame
+    model_name: str
+    success: bool
+    message: str = ""
+
+    def combined(self) -> pd.DataFrame:
+        return pd.concat([self.history, self.forecast], ignore_index=True, sort=False)
+
+
+def _prepare_series(
+    df: pd.DataFrame,
+    *,
+    value_column: str,
+    date_column: str = "date",
+    frequency: str = "monthly",
+) -> pd.Series:
+    if df.empty:
+        return pd.Series(dtype=float)
+    frame = df.copy()
+    if date_column not in frame.columns:
+        raise KeyError(f"Column '{date_column}' is required for forecasting.")
+    frame[date_column] = pd.to_datetime(frame[date_column], errors="coerce")
+    frame = frame.dropna(subset=[date_column])
+    frame = frame.sort_values(date_column)
+    freq = FREQUENCY_MAP.get(frequency, "MS")
+    series = frame.set_index(date_column)[value_column].resample(freq).sum()
+    return series.astype(float)
+
+
+def _run_prophet(series: pd.Series, periods: int, frequency: str) -> Optional[pd.DataFrame]:
+    if Prophet is None or series.empty:
+        return None
+    frame = series.reset_index()
+    frame.columns = ["ds", "y"]
+    model = Prophet(interval_width=0.8, daily_seasonality=False, weekly_seasonality=False)
+    if frequency in ("daily", "weekly"):
+        model.weekly_seasonality = True
+    if frequency == "daily":
+        model.daily_seasonality = True
+    if frequency == "monthly":
+        model.yearly_seasonality = True
+    model.fit(frame)
+    future = model.make_future_dataframe(periods=periods, freq=FREQUENCY_MAP.get(frequency, "MS"))
+    forecast = model.predict(future)
+    result = forecast[["ds", "yhat", "yhat_lower", "yhat_upper"]].tail(periods)
+    result = result.rename(columns={"ds": "date", "yhat": "forecast"})
+    return result
+
+
+def _run_arima(series: pd.Series, periods: int) -> Optional[pd.DataFrame]:
+    if ARIMA is None or series.empty:
+        return None
+    model = ARIMA(series, order=(1, 1, 1))
+    fitted = model.fit()
+    forecast_res = fitted.get_forecast(steps=periods)
+    frame = forecast_res.summary_frame(alpha=0.2)
+    frame = frame.rename(
+        columns={
+            "mean": "forecast",
+            "mean_ci_lower": "forecast_lower",
+            "mean_ci_upper": "forecast_upper",
+        }
+    )
+    frame = frame.reset_index().rename(columns={"index": "date"})
+    return frame
+
+
+def build_forecast(
+    df: pd.DataFrame,
+    *,
+    value_column: str,
+    date_column: str = "date",
+    periods: int = 6,
+    frequency: str = "monthly",
+) -> ForecastResult:
+    """Create a forecast using Prophet or ARIMA and return a :class:`ForecastResult`."""
+
+    series = _prepare_series(
+        df,
+        value_column=value_column,
+        date_column=date_column,
+        frequency=frequency,
+    )
+    history_df = series.reset_index().rename(columns={"index": "date", value_column: "actual"})
+    history_df = history_df.rename(columns={series.name or "actual": "actual"})
+
+    forecast_frame: Optional[pd.DataFrame] = None
+    model_name = ""
+    message = ""
+
+    try:
+        forecast_frame = _run_prophet(series, periods, frequency)
+        model_name = "Prophet"
+    except Exception as exc:  # pragma: no cover - best effort fallback
+        message = f"Prophet forecast failed: {exc}"
+
+    if forecast_frame is None:
+        try:
+            forecast_frame = _run_arima(series, periods)
+            model_name = model_name or "ARIMA"
+        except Exception as exc:  # pragma: no cover
+            message = message or f"ARIMA forecast failed: {exc}"
+
+    if forecast_frame is None or forecast_frame.empty:
+        fallback = pd.DataFrame(
+            {
+                "date": pd.date_range(
+                    start=series.index.max() if not series.empty else pd.Timestamp.today(),
+                    periods=periods,
+                    freq=FREQUENCY_MAP.get(frequency, "MS"),
+                ),
+                "forecast": np.nan,
+                "forecast_lower": np.nan,
+                "forecast_upper": np.nan,
+            }
+        )
+        return ForecastResult(
+            history=history_df,
+            forecast=fallback,
+            model_name=model_name or "moving_average",
+            success=False,
+            message=message or "利用可能な予測モデルがありませんでした。",
+        )
+
+    if "forecast_lower" not in forecast_frame.columns:
+        forecast_frame["forecast_lower"] = forecast_frame["forecast"].astype(float)
+    if "forecast_upper" not in forecast_frame.columns:
+        forecast_frame["forecast_upper"] = forecast_frame["forecast"].astype(float)
+    forecast_frame = forecast_frame.rename(
+        columns={
+            "yhat_lower": "forecast_lower",
+            "yhat_upper": "forecast_upper",
+        }
+    )
+    forecast_frame["forecast"] = forecast_frame["forecast"].astype(float)
+
+    return ForecastResult(
+        history=history_df,
+        forecast=forecast_frame,
+        model_name=model_name or "Prophet",
+        success=True,
+        message=message,
+    )
+
+
+def evaluate_accuracy(
+    result: ForecastResult,
+    actual_df: pd.DataFrame,
+    *,
+    value_column: str,
+    date_column: str = "date",
+    frequency: str = "monthly",
+) -> pd.DataFrame:
+    """Calculate MAPE and absolute errors between forecast and realised values."""
+
+    if result.forecast.empty or actual_df.empty:
+        return pd.DataFrame(columns=["date", "forecast", "actual", "abs_error", "ape"])
+
+    realised = actual_df.copy()
+    realised[date_column] = pd.to_datetime(realised[date_column], errors="coerce")
+    realised = realised.dropna(subset=[date_column])
+    realised = realised.sort_values(date_column)
+    aggregated = (
+        realised.set_index(date_column)
+        .resample(FREQUENCY_MAP.get(frequency, "MS"))
+        [value_column]
+        .sum()
+        .reset_index()
+    )
+    merged = result.forecast.merge(
+        aggregated.rename(columns={value_column: "actual"}),
+        on="date",
+        how="left",
+    )
+    merged["abs_error"] = (merged["forecast"] - merged["actual"]).abs()
+    merged["ape"] = merged["abs_error"] / merged["actual"].replace(0, np.nan)
+    merged["ape"] = merged["ape"].fillna(0.0)
+    return merged
+
+
+def forecast_sales(
+    df: pd.DataFrame,
+    *,
+    periods: int = 6,
+    frequency: str = "monthly",
+) -> ForecastResult:
+    return build_forecast(
+        df,
+        value_column="sales_amount",
+        date_column="date",
+        periods=periods,
+        frequency=frequency,
+    )
+
+
+__all__ = [
+    "ForecastResult",
+    "build_forecast",
+    "evaluate_accuracy",
+    "forecast_sales",
+]

--- a/streamlit_app/integrations/__init__.py
+++ b/streamlit_app/integrations/__init__.py
@@ -2,6 +2,13 @@
 
 from .benchmarks import DEFAULT_BENCHMARKS, fetch_benchmark_indicators
 from .manager import IntegrationResult, available_providers, fetch_datasets
+from .sync import (
+    BatchJob,
+    IntegrationSyncManager,
+    RPAJob,
+    WebhookEvent,
+    merge_results,
+)
 
 __all__ = [
     "DEFAULT_BENCHMARKS",
@@ -9,4 +16,9 @@ __all__ = [
     "available_providers",
     "fetch_benchmark_indicators",
     "fetch_datasets",
+    "BatchJob",
+    "IntegrationSyncManager",
+    "WebhookEvent",
+    "RPAJob",
+    "merge_results",
 ]

--- a/streamlit_app/integrations/sync.py
+++ b/streamlit_app/integrations/sync.py
@@ -1,0 +1,218 @@
+"""Utilities for orchestrating scheduled and event-driven data synchronisation."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime, time, timedelta
+from typing import Dict, Iterable, List, Optional
+
+import pandas as pd
+
+from .manager import IntegrationResult, fetch_datasets
+
+
+@dataclass
+class BatchJob:
+    """Represents a periodic batch job that synchronises datasets via the API."""
+
+    provider: str
+    run_time: time = time(hour=5, minute=0)
+    frequency: str = "daily"
+    lookback_days: int = 1
+    enabled: bool = True
+    last_run: Optional[date] = None
+
+    def is_due(self, *, now: Optional[datetime] = None) -> bool:
+        """Return ``True`` when the batch job should execute."""
+
+        if not self.enabled:
+            return False
+        moment = now or datetime.utcnow()
+        if self.frequency != "daily":
+            return False
+        if self.last_run == moment.date():
+            return False
+        return moment.time() >= self.run_time
+
+    def execution_window(self, *, reference: Optional[datetime] = None) -> tuple[date, date]:
+        """Return the start/end date for the next fetch window."""
+
+        moment = reference or datetime.utcnow()
+        end = moment.date() - timedelta(days=1)
+        start = end - timedelta(days=max(self.lookback_days - 1, 0))
+        return start, end
+
+
+@dataclass
+class WebhookEvent:
+    """Payload captured from a webhook callback."""
+
+    provider: str
+    payload: Dict[str, object]
+    received_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class RPAJob:
+    """Definition of an automated CSV retrieval job via simple RPA."""
+
+    name: str
+    url: str
+    dataset: str
+    last_fetched: Optional[datetime] = None
+
+
+class IntegrationSyncManager:
+    """Stateful helper that encapsulates batch, webhook, and RPA ingestion flows."""
+
+    def __init__(self) -> None:
+        self.batch_jobs: Dict[str, BatchJob] = {}
+        self.webhook_queue: List[WebhookEvent] = []
+        self.rpa_jobs: Dict[str, RPAJob] = {}
+
+    # ------------------------------------------------------------------
+    # Batch scheduling
+    # ------------------------------------------------------------------
+    def enable_daily_batch(
+        self,
+        provider: str,
+        *,
+        run_time: time = time(hour=5, minute=0),
+        lookback_days: int = 1,
+    ) -> None:
+        """Register or update a daily batch job."""
+
+        job = self.batch_jobs.get(provider) or BatchJob(provider=provider)
+        job.run_time = run_time
+        job.lookback_days = max(1, int(lookback_days))
+        job.frequency = "daily"
+        job.enabled = True
+        self.batch_jobs[provider] = job
+
+    def disable_batch(self, provider: str) -> None:
+        """Disable the batch job for ``provider`` if it exists."""
+
+        job = self.batch_jobs.get(provider)
+        if job:
+            job.enabled = False
+
+    def run_pending_batches(
+        self,
+        *,
+        credentials: Dict[str, Dict[str, str]],
+        now: Optional[datetime] = None,
+    ) -> List[IntegrationResult]:
+        """Execute all due batch jobs and return the resulting integrations."""
+
+        executed: List[IntegrationResult] = []
+        moment = now or datetime.utcnow()
+        for provider, job in list(self.batch_jobs.items()):
+            if not job.is_due(now=moment):
+                continue
+            start, end = job.execution_window(reference=moment)
+            provider_credentials = credentials.get(provider, {})
+            result = fetch_datasets(provider, start, end, provider_credentials)
+            job.last_run = moment.date()
+            executed.append(result)
+        return executed
+
+    # ------------------------------------------------------------------
+    # Webhook processing
+    # ------------------------------------------------------------------
+    def queue_webhook(self, provider: str, payload: Dict[str, object]) -> None:
+        """Store an inbound webhook payload for asynchronous processing."""
+
+        self.webhook_queue.append(WebhookEvent(provider=provider, payload=payload))
+
+    def process_webhooks(
+        self,
+        *,
+        credentials: Dict[str, Dict[str, str]],
+    ) -> List[IntegrationResult]:
+        """Process queued webhook events and return executed integrations."""
+
+        results: List[IntegrationResult] = []
+        remaining: List[WebhookEvent] = []
+        while self.webhook_queue:
+            event = self.webhook_queue.pop(0)
+            try:
+                start_raw = event.payload.get("start_date")
+                end_raw = event.payload.get("end_date")
+                if start_raw and end_raw:
+                    start = date.fromisoformat(str(start_raw))
+                    end = date.fromisoformat(str(end_raw))
+                else:
+                    # When no explicit range is provided we fallback to yesterday.
+                    today = event.received_at.date()
+                    end = today
+                    start = today
+                provider_credentials = credentials.get(event.provider, {})
+                result = fetch_datasets(event.provider, start, end, provider_credentials)
+                results.append(result)
+            except Exception:  # pragma: no cover - defensive branch
+                remaining.append(event)
+        self.webhook_queue = remaining
+        return results
+
+    # ------------------------------------------------------------------
+    # RPA automation
+    # ------------------------------------------------------------------
+    def register_rpa_job(self, name: str, url: str, dataset: str) -> None:
+        """Register a simple RPA workflow that downloads a CSV and feeds it into the app."""
+
+        self.rpa_jobs[name] = RPAJob(name=name, url=url, dataset=dataset)
+
+    def run_rpa_jobs(self) -> Dict[str, pd.DataFrame]:
+        """Execute registered RPA CSV fetches and return parsed dataframes."""
+
+        from io import StringIO
+
+        import requests
+
+        datasets: Dict[str, pd.DataFrame] = {}
+        for job in self.rpa_jobs.values():
+            try:
+                response = requests.get(job.url, timeout=15)
+                response.raise_for_status()
+                buffer = StringIO(response.text)
+                datasets[job.dataset] = pd.read_csv(buffer)
+                job.last_fetched = datetime.utcnow()
+            except Exception:  # pragma: no cover - network guard
+                continue
+        return datasets
+
+
+def merge_results(results: Iterable[IntegrationResult]) -> Optional[IntegrationResult]:
+    """Merge multiple integration results into a single consolidated object."""
+
+    results = list(results)
+    if not results:
+        return None
+    primary = results[0]
+    merged_datasets: Dict[str, pd.DataFrame] = {k: v.copy() for k, v in primary.datasets.items()}
+    message_parts = [primary.message]
+    for result in results[1:]:
+        message_parts.append(result.message)
+        for name, df in result.datasets.items():
+            if name in merged_datasets:
+                merged_datasets[name] = pd.concat(
+                    [merged_datasets[name], df], ignore_index=True, sort=False
+                ).drop_duplicates()
+            else:
+                merged_datasets[name] = df.copy()
+    return IntegrationResult(
+        provider=primary.provider,
+        start_date=min(result.start_date for result in results),
+        end_date=max(result.end_date for result in results),
+        datasets=merged_datasets,
+        message=" / ".join(filter(None, message_parts)),
+        retrieved_at=max(result.retrieved_at for result in results),
+    )
+
+
+__all__ = [
+    "BatchJob",
+    "IntegrationSyncManager",
+    "WebhookEvent",
+    "RPAJob",
+    "merge_results",
+]


### PR DESCRIPTION
## Summary
- add REST integration client improvements with scheduling, webhook, and RPA helpers and surface new API controls in the sidebar
- introduce multi-axis sales analysis, hierarchical treemap/sunburst visuals, and ARIMA/Prophet-backed forecasting with accuracy reporting
- extend alerts and theming by adding decision-support rules, language/theme toggles, and adaptive design tokens

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e772e65dac832384fc1139b2acab51